### PR TITLE
Refactor tests to comply with test-patterns.mdc

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,3 +54,12 @@ def dbsession(session_factory):
 @pytest.fixture()
 def fake_request():
     return FakeRequest()
+
+
+@pytest.fixture()
+def request_dbsession(session_factory, fake_request):
+    """Session bound to a fake request — handles rollback and close automatically."""
+    session = session_factory(info={"request": fake_request})
+    yield session
+    session.rollback()
+    session.close()

--- a/tests/test_includeme.py
+++ b/tests/test_includeme.py
@@ -1,80 +1,87 @@
 """Tests for pyramid_sa.includeme — Pyramid integration."""
 
+import datetime
+
 import webtest
 from pyramid.config import Configurator
 from sqlalchemy import create_engine
+from sqlalchemy.orm.exc import NoResultFound
 
 from pyramid_sa import Base
 
 
-class TestIncludeme:
-    def test_registers_dbsession_factory(self):
-        config = Configurator(settings={"sqlalchemy.url": "sqlite://"})
-        config.include("pyramid_sa")
-        config.commit()
+def test_registers_dbsession_factory():
+    """Verify includeme registers a dbsession_factory in the registry."""
+    config = Configurator(settings={"sqlalchemy.url": "sqlite://"})
+    config.include("pyramid_sa")
+    config.commit()
 
-        assert "dbsession_factory" in config.registry
+    assert "dbsession_factory" in config.registry
 
-    def test_uses_pre_set_dbengine(self):
-        engine = create_engine("sqlite://")
-        config = Configurator(settings={})
-        config.registry["dbengine"] = engine
-        config.include("pyramid_sa")
-        config.commit()
 
-        factory = config.registry["dbsession_factory"]
-        assert factory.kw["bind"] is engine
+def test_uses_pre_set_dbengine():
+    """Verify includeme reuses an engine already set in the registry."""
+    engine = create_engine("sqlite://")
+    config = Configurator(settings={})
+    config.registry["dbengine"] = engine
+    config.include("pyramid_sa")
+    config.commit()
 
-    def test_request_dbsession_via_webtest(self):
-        engine = create_engine("sqlite://")
-        Base.metadata.create_all(engine)
+    factory = config.registry["dbsession_factory"]
+    assert factory.kw["bind"] is engine
 
-        config = Configurator(settings={})
-        config.registry["dbengine"] = engine
-        config.include("pyramid_sa")
-        config.add_route("check", "/check")
-        config.add_view(
-            lambda request: {"has_dbsession": hasattr(request, "dbsession")},
-            route_name="check",
-            renderer="json",
-        )
-        app = config.make_wsgi_app()
-        testapp = webtest.TestApp(app)
 
-        response = testapp.get("/check")
-        assert response.json["has_dbsession"] is True
+def test_request_dbsession_via_webtest():
+    """Verify requests have a dbsession attribute after includeme."""
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
 
-    def test_exception_tween_returns_404_for_not_found(self):
-        from sqlalchemy.orm.exc import NoResultFound
+    config = Configurator(settings={})
+    config.registry["dbengine"] = engine
+    config.include("pyramid_sa")
+    config.add_route("check", "/check")
+    config.add_view(
+        lambda request: {"has_dbsession": hasattr(request, "dbsession")},
+        route_name="check",
+        renderer="json",
+    )
+    app = config.make_wsgi_app()
+    testapp = webtest.TestApp(app)
 
-        config = Configurator(settings={"sqlalchemy.url": "sqlite://"})
-        config.include("pyramid_sa")
-        config.add_route("fail", "/fail")
+    response = testapp.get("/check")
+    assert response.json["has_dbsession"] is True
 
-        def failing_view(request):
-            raise NoResultFound()
 
-        config.add_view(failing_view, route_name="fail", renderer="json")
-        app = config.make_wsgi_app()
-        testapp = webtest.TestApp(app)
+def test_exception_tween_returns_404_for_not_found():
+    """Verify the exception tween maps NoResultFound to a 404 response."""
+    config = Configurator(settings={"sqlalchemy.url": "sqlite://"})
+    config.include("pyramid_sa")
+    config.add_route("fail", "/fail")
 
-        response = testapp.get("/fail", expect_errors=True)
-        assert response.status_int == 404
-        assert response.json["error"] == "not_found"
+    def failing_view(request):
+        raise NoResultFound()
 
-    def test_json_renderer_handles_datetime(self):
-        import datetime
+    config.add_view(failing_view, route_name="fail", renderer="json")
+    app = config.make_wsgi_app()
+    testapp = webtest.TestApp(app)
 
-        config = Configurator(settings={"sqlalchemy.url": "sqlite://"})
-        config.include("pyramid_sa")
-        config.add_route("time", "/time")
-        config.add_view(
-            lambda request: {"ts": datetime.datetime(2026, 3, 21, 12, 0, 0)},
-            route_name="time",
-            renderer="json",
-        )
-        app = config.make_wsgi_app()
-        testapp = webtest.TestApp(app)
+    response = testapp.get("/fail", expect_errors=True)
+    assert response.status_int == 404
+    assert response.json["error"] == "not_found"
 
-        response = testapp.get("/time")
-        assert response.json["ts"] == "2026-03-21T12:00:00"
+
+def test_json_renderer_handles_datetime():
+    """Verify the JSON renderer serializes datetime to ISO-8601."""
+    config = Configurator(settings={"sqlalchemy.url": "sqlite://"})
+    config.include("pyramid_sa")
+    config.add_route("time", "/time")
+    config.add_view(
+        lambda request: {"ts": datetime.datetime(2026, 3, 21, 12, 0, 0)},
+        route_name="time",
+        renderer="json",
+    )
+    app = config.make_wsgi_app()
+    testapp = webtest.TestApp(app)
+
+    response = testapp.get("/time")
+    assert response.json["ts"] == "2026-03-21T12:00:00"

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -3,89 +3,97 @@
 from tests.conftest import Item
 
 
-class TestAuditMixin:
-    def test_as_dict_returns_column_values(self, dbsession):
-        item = Item(name="test-item")
-        dbsession.add(item)
-        dbsession.flush()
+def test_as_dict_returns_column_values(dbsession):
+    """Verify as_dict includes all column values."""
+    item = Item(name="test-item")
+    dbsession.add(item)
+    dbsession.flush()
 
-        result = item.as_dict()
-        assert result["name"] == "test-item"
-
-    def test_as_dict_hides_internal_id(self, dbsession):
-        item = Item(name="test-item")
-        dbsession.add(item)
-        dbsession.flush()
-
-        result = item.as_dict(hide_internal_fields=True)
-        assert "id" in result
-        assert result["id"] == item.uuid
-
-    def test_as_dict_converts_to_camel_case(self, dbsession):
-        item = Item(name="test-item")
-        dbsession.add(item)
-        dbsession.flush()
-
-        result = item.as_dict(convert_to_camel=True)
-        assert "createdAt" in result
-
-    def test_as_dict_no_camel(self, dbsession):
-        item = Item(name="test-item")
-        dbsession.add(item)
-        dbsession.flush()
-
-        result = item.as_dict(convert_to_camel=False)
-        assert "created_at" in result
-
-    def test_as_dict_exclude(self, dbsession):
-        item = Item(name="test-item")
-        dbsession.add(item)
-        dbsession.flush()
-
-        result = item.as_dict(exclude=["name"])
-        assert "name" not in result
-
-    def test_copy_with(self, dbsession):
-        item = Item(name="original")
-        dbsession.add(item)
-        dbsession.flush()
-
-        copy = item.copy_with(name="copy")
-        assert copy.name == "copy"
-        assert copy.id is None
-        assert isinstance(copy, Item)
+    result = item.as_dict()
+    assert result["name"] == "test-item"
 
 
-class TestEventListeners:
-    def test_before_insert_sets_created_by(self, session_factory, fake_request):
-        session = session_factory(info={"request": fake_request})
-        item = Item(name="audited-item")
-        session.add(item)
-        session.flush()
+def test_as_dict_hides_internal_id(dbsession):
+    """Verify as_dict replaces the integer id with uuid when hiding internals."""
+    item = Item(name="test-item")
+    dbsession.add(item)
+    dbsession.flush()
 
-        assert item.created_by == "test-user"
-        assert item.created_ip == "127.0.0.1"
-        session.rollback()
-        session.close()
+    result = item.as_dict(hide_internal_fields=True)
+    assert "id" in result
+    assert result["id"] == item.uuid
 
-    def test_before_update_sets_updated_by(self, session_factory, fake_request):
-        session = session_factory(info={"request": fake_request})
-        item = Item(name="audited-item")
-        session.add(item)
-        session.flush()
 
-        item.name = "updated-name"
-        session.flush()
+def test_as_dict_converts_to_camel_case(dbsession):
+    """Verify as_dict converts snake_case keys to camelCase."""
+    item = Item(name="test-item")
+    dbsession.add(item)
+    dbsession.flush()
 
-        assert item.updated_by == "test-user"
-        assert item.updated_ip == "127.0.0.1"
-        session.rollback()
-        session.close()
+    result = item.as_dict(convert_to_camel=True)
+    assert "createdAt" in result
 
-    def test_no_request_does_not_fail(self, dbsession):
-        item = Item(name="no-request")
-        dbsession.add(item)
-        dbsession.flush()
 
-        assert item.created_by is None
-        assert item.created_ip is None
+def test_as_dict_no_camel(dbsession):
+    """Verify as_dict preserves snake_case keys when camel conversion is off."""
+    item = Item(name="test-item")
+    dbsession.add(item)
+    dbsession.flush()
+
+    result = item.as_dict(convert_to_camel=False)
+    assert "created_at" in result
+
+
+def test_as_dict_exclude(dbsession):
+    """Verify as_dict omits excluded fields from the result."""
+    item = Item(name="test-item")
+    dbsession.add(item)
+    dbsession.flush()
+
+    result = item.as_dict(exclude=["name"])
+    assert "name" not in result
+
+
+def test_copy_with(dbsession):
+    """Verify copy_with creates a detached copy with overridden attributes."""
+    item = Item(name="original")
+    dbsession.add(item)
+    dbsession.flush()
+
+    copy = item.copy_with(name="copy")
+    assert copy.name == "copy"
+    assert copy.id is None
+    assert isinstance(copy, Item)
+
+
+def test_before_insert_sets_created_by(request_dbsession):
+    """Verify the before_insert listener populates created_by and created_ip."""
+    item = Item(name="audited-item")
+    request_dbsession.add(item)
+    request_dbsession.flush()
+
+    assert item.created_by == "test-user"
+    assert item.created_ip == "127.0.0.1"
+
+
+def test_before_update_sets_updated_by(request_dbsession):
+    """Verify the before_update listener populates updated_by and updated_ip."""
+    item = Item(name="audited-item")
+    request_dbsession.add(item)
+    request_dbsession.flush()
+
+    item.name = "updated-name"
+    request_dbsession.flush()
+
+    assert item.updated_by == "test-user"
+    assert item.updated_ip == "127.0.0.1"
+
+
+def test_no_request_does_not_fail(dbsession):
+    """Verify audit listeners gracefully handle sessions without a request."""
+    item = Item(name="no-request")
+    dbsession.add(item)
+    dbsession.flush()
+
+    assert item.created_by is None
+    assert item.created_ip is None

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -3,53 +3,62 @@
 import datetime
 from uuid import uuid4
 
+import pytest
 import webtest
 from pyramid.config import Configurator
 
 
-class TestJsonRenderer:
-    def test_datetime_serialized_as_iso(self):
-        config = Configurator(settings={"sqlalchemy.url": "sqlite://"})
-        config.include("pyramid_sa")
-        config.add_route("dt", "/dt")
-        config.add_view(
-            lambda r: {"ts": datetime.datetime(2026, 3, 21, 12, 0, 0)},
-            route_name="dt",
-            renderer="json",
-        )
-        app = config.make_wsgi_app()
-        testapp = webtest.TestApp(app)
+@pytest.fixture()
+def renderer_app():
+    """Pyramid WSGI app with pyramid_sa included, ready for route registration."""
+    config = Configurator(settings={"sqlalchemy.url": "sqlite://"})
+    config.include("pyramid_sa")
+    return config
 
-        response = testapp.get("/dt")
-        assert response.json["ts"] == "2026-03-21T12:00:00"
 
-    def test_date_serialized_as_iso(self):
-        config = Configurator(settings={"sqlalchemy.url": "sqlite://"})
-        config.include("pyramid_sa")
-        config.add_route("d", "/d")
-        config.add_view(
-            lambda r: {"date": datetime.date(2026, 3, 21)},
-            route_name="d",
-            renderer="json",
-        )
-        app = config.make_wsgi_app()
-        testapp = webtest.TestApp(app)
+def _make_testapp(config: Configurator) -> webtest.TestApp:
+    """Build a TestApp from a Configurator that already has routes registered."""
+    return webtest.TestApp(config.make_wsgi_app())
 
-        response = testapp.get("/d")
-        assert response.json["date"] == "2026-03-21"
 
-    def test_uuid_serialized_as_string(self):
-        u = uuid4()
-        config = Configurator(settings={"sqlalchemy.url": "sqlite://"})
-        config.include("pyramid_sa")
-        config.add_route("u", "/u")
-        config.add_view(
-            lambda r: {"id": u},
-            route_name="u",
-            renderer="json",
-        )
-        app = config.make_wsgi_app()
-        testapp = webtest.TestApp(app)
+def test_datetime_serialized_as_iso(renderer_app):
+    """Verify datetime objects are serialized to ISO-8601 strings."""
+    renderer_app.add_route("dt", "/dt")
+    renderer_app.add_view(
+        lambda r: {"ts": datetime.datetime(2026, 3, 21, 12, 0, 0)},
+        route_name="dt",
+        renderer="json",
+    )
+    testapp = _make_testapp(renderer_app)
 
-        response = testapp.get("/u")
-        assert response.json["id"] == str(u)
+    response = testapp.get("/dt")
+    assert response.json["ts"] == "2026-03-21T12:00:00"
+
+
+def test_date_serialized_as_iso(renderer_app):
+    """Verify date objects are serialized to ISO-8601 strings."""
+    renderer_app.add_route("d", "/d")
+    renderer_app.add_view(
+        lambda r: {"date": datetime.date(2026, 3, 21)},
+        route_name="d",
+        renderer="json",
+    )
+    testapp = _make_testapp(renderer_app)
+
+    response = testapp.get("/d")
+    assert response.json["date"] == "2026-03-21"
+
+
+def test_uuid_serialized_as_string(renderer_app):
+    """Verify UUID objects are serialized to their string representation."""
+    u = uuid4()
+    renderer_app.add_route("u", "/u")
+    renderer_app.add_view(
+        lambda r: {"id": u},
+        route_name="u",
+        renderer="json",
+    )
+    testapp = _make_testapp(renderer_app)
+
+    response = testapp.get("/u")
+    assert response.json["id"] == str(u)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -48,26 +48,33 @@ def app(pyramid_sa_engine):
     return wsgi_app
 
 
-class TestPluginFixtures:
-    def test_tm_is_doomed(self, pyramid_sa_tm):
-        assert pyramid_sa_tm.isDoomed()
+def test_tm_is_doomed(pyramid_sa_tm):
+    """Verify the transaction manager starts in a doomed state."""
+    assert pyramid_sa_tm.isDoomed()
 
-    def test_dbsession_works(self, pyramid_sa_dbsession):
-        widget = Widget(label="test-widget")
-        pyramid_sa_dbsession.add(widget)
-        pyramid_sa_dbsession.flush()
 
-        assert widget.id is not None
-        assert widget.label == "test-widget"
+def test_dbsession_works(pyramid_sa_dbsession):
+    """Verify the plugin dbsession can persist and flush objects."""
+    widget = Widget(label="test-widget")
+    pyramid_sa_dbsession.add(widget)
+    pyramid_sa_dbsession.flush()
 
-    def test_testapp_makes_requests(self, pyramid_sa_testapp):
-        response = pyramid_sa_testapp.get("/health", status=200)
-        assert response.json["status"] == "ok"
+    assert widget.id is not None
+    assert widget.label == "test-widget"
 
-    def test_app_request_has_dbsession(self, pyramid_sa_app_request):
-        assert pyramid_sa_app_request.dbsession is not None
 
-    def test_dbsession_rolls_back_between_tests(self, pyramid_sa_dbsession):
-        """This test runs after test_dbsession_works — the widget should not exist."""
-        count = pyramid_sa_dbsession.query(Widget).count()
-        assert count == 0
+def test_testapp_makes_requests(pyramid_sa_testapp):
+    """Verify the plugin testapp can send HTTP requests."""
+    response = pyramid_sa_testapp.get("/health", status=200)
+    assert response.json["status"] == "ok"
+
+
+def test_app_request_has_dbsession(pyramid_sa_app_request):
+    """Verify the app request object has a dbsession attribute."""
+    assert pyramid_sa_app_request.dbsession is not None
+
+
+def test_dbsession_rolls_back_between_tests(pyramid_sa_dbsession):
+    """This test runs after test_dbsession_works — the widget should not exist."""
+    count = pyramid_sa_dbsession.query(Widget).count()
+    assert count == 0

--- a/tests/test_tween.py
+++ b/tests/test_tween.py
@@ -9,47 +9,57 @@ from sqlalchemy.orm.exc import NoResultFound
 from pyramid_sa.tween import exception_tween_factory
 
 
-class TestExceptionTween:
-    def test_no_result_found_returns_404(self):
-        def handler(request):
-            raise NoResultFound()
+def test_no_result_found_returns_404():
+    """Verify NoResultFound is mapped to a 404 HTTPNotFound."""
 
-        tween = exception_tween_factory(handler, None)
-        request = pyramid_testing.DummyRequest()
+    def handler(request):
+        raise NoResultFound()
 
-        with pytest.raises(HTTPNotFound) as exc_info:
-            tween(request)
+    tween = exception_tween_factory(handler, None)
+    request = pyramid_testing.DummyRequest()
 
-        assert exc_info.value.json_body["error"] == "not_found"
+    with pytest.raises(HTTPNotFound) as exc_info:
+        tween(request)
 
-    def test_integrity_error_returns_409(self):
-        def handler(request):
-            raise IntegrityError("INSERT ...", {}, Exception("duplicate key"))
+    assert exc_info.value.json_body["error"] == "not_found"
 
-        tween = exception_tween_factory(handler, None)
-        request = pyramid_testing.DummyRequest()
 
-        with pytest.raises(HTTPConflict) as exc_info:
-            tween(request)
+def test_integrity_error_returns_409():
+    """Verify IntegrityError is mapped to a 409 HTTPConflict."""
 
-        assert exc_info.value.json_body["error"] == "conflict"
+    def handler(request):
+        raise IntegrityError("INSERT ...", {}, Exception("duplicate key"))
 
-    def test_normal_response_passes_through(self):
-        def handler(request):
-            return {"status": "ok"}
+    tween = exception_tween_factory(handler, None)
+    request = pyramid_testing.DummyRequest()
 
-        tween = exception_tween_factory(handler, None)
-        request = pyramid_testing.DummyRequest()
+    with pytest.raises(HTTPConflict) as exc_info:
+        tween(request)
 
-        result = tween(request)
-        assert result == {"status": "ok"}
+    assert exc_info.value.json_body["error"] == "conflict"
 
-    def test_other_exceptions_propagate(self):
-        def handler(request):
-            raise ValueError("unrelated")
 
-        tween = exception_tween_factory(handler, None)
-        request = pyramid_testing.DummyRequest()
+def test_normal_response_passes_through():
+    """Verify a normal response is returned unchanged."""
 
-        with pytest.raises(ValueError, match="unrelated"):
-            tween(request)
+    def handler(request):
+        return {"status": "ok"}
+
+    tween = exception_tween_factory(handler, None)
+    request = pyramid_testing.DummyRequest()
+
+    result = tween(request)
+    assert result == {"status": "ok"}
+
+
+def test_other_exceptions_propagate():
+    """Verify unhandled exceptions propagate without being caught."""
+
+    def handler(request):
+        raise ValueError("unrelated")
+
+    tween = exception_tween_factory(handler, None)
+    request = pyramid_testing.DummyRequest()
+
+    with pytest.raises(ValueError, match="unrelated"):
+        tween(request)


### PR DESCRIPTION
## Summary

- Converted all class-based tests to plain pytest functions across all 5 test files (26 tests total)
- Added docstrings to every test function describing the behavior being verified
- Moved inline imports to module level in `test_includeme.py`
- Extracted repeated Configurator/WebTest setup into a `renderer_app` fixture in `test_renderer.py`
- Added `request_dbsession` fixture to `conftest.py` for sessions bound to a fake request with automatic cleanup
- Replaced manual `session.rollback()` / `session.close()` calls in `test_meta.py` with the new fixture

Closes #1

## Test plan

- [x] All 26 tests pass (`uv run pytest -v`)
- [x] Ruff linting passes (`uv run ruff check tests/`)
- [x] Black formatting passes (`uv run black --check tests/`)
- [x] No test behavior changed — only structural refactoring