### PR TITLE
Switch test suite from SQLite to PostgreSQL using pytest-postgresql

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/python:3.13
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql postgresql-client \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,8 @@
 {
   "name": "pyramid-sa",
-  "image": "mcr.microsoft.com/devcontainers/python:3.13",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/aws-cli:1": {}

--- a/knowledge/architecture.md
+++ b/knowledge/architecture.md
@@ -38,6 +38,18 @@ Mixins provide **columns** at import time. Directives activate **behavior** at a
 - `config.sa_enable_audit()` registers event listeners that populate audit fields from the request
 - `config.sa_enable_soft_delete()` registers event listeners scoped to the app's sessionmaker (not global)
 
+## Test Infrastructure
+
+All tests run against PostgreSQL via pytest-postgresql. The `postgresql_proc` fixture (auto-registered by the plugin) starts a temporary PostgreSQL process on a random port per test session. Each `db_engine` fixture builds a `postgresql+psycopg://` URL from the process connection info. Doomed transactions provide per-test isolation.
+
+The soft-delete test module uses a dedicated database (`test_soft_delete`) because `sa_enable_soft_delete()` transforms unique constraints into partial indexes. Other modules share the default `postgres` database.
+
+The `pyramid_sa_testing` plugin provides `pyramid_sa_engine` (backed by `postgresql_proc`), `pyramid_sa_tm`, `pyramid_sa_dbsession`, `pyramid_sa_testapp`, and `pyramid_sa_app_request` fixtures.
+
+The devcontainer Dockerfile installs PostgreSQL server binaries so `postgresql_proc` can start its own instance.
+
 ## External Dependencies
 
 pyramid, sqlalchemy, alembic, pyramid-tm, zope-sqlalchemy, click, camel-converter
+
+Dev/test: pytest-postgresql, psycopg

--- a/knowledge/decisions.md
+++ b/knowledge/decisions.md
@@ -80,6 +80,16 @@ Use this format when adding a new decision:
 
 **Consequences**: Each Pyramid app gets exactly the soft-delete behavior it opted into. Multiple apps in the same process (common in tests) don't interfere with each other.
 
+### 2026-03-22 — PostgreSQL test infrastructure via pytest-postgresql
+
+**Status**: Accepted
+
+**Context**: All tests ran against SQLite in-memory. The library had partial PostgreSQL awareness (e.g. `postgresql_where` in soft-delete partial indexes) but had never been tested against a real PostgreSQL instance. SQLite's behavioral differences (e.g. lack of real partial unique indexes) meant bugs could reach production undetected.
+
+**Decision**: Switch the entire test suite to PostgreSQL using pytest-postgresql. The `postgresql_proc` fixture starts a temporary PostgreSQL process per test session. The devcontainer Dockerfile installs PostgreSQL server binaries. The soft-delete module uses a dedicated database because its metadata transformation (unique constraints to partial indexes) conflicts with tables created by other modules before the transformation runs.
+
+**Consequences**: Tests now validate against real PostgreSQL behavior. The soft-delete partial unique index test, which passed on SQLite by coincidence, was validated to work correctly on PostgreSQL. The testing plugin (`pyramid-sa-testing`) also defaults to PostgreSQL, so consuming apps get PostgreSQL testing out of the box. The devcontainer image is slightly larger due to PostgreSQL server packages.
+
 ### 2026-03-22 — Configurable exception tween error body formatters
 
 **Status**: Accepted

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,4 +50,6 @@ dev = [
     "transaction",
     "waitress",
     "pyramid-sa-testing",
+    "pytest-postgresql",
+    "psycopg",
 ]

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -8,6 +8,8 @@ dependencies = [
     "pyramid-sa",
     "webtest",
     "transaction",
+    "pytest-postgresql",
+    "psycopg",
 ]
 
 [tool.uv.sources]

--- a/testing/src/pyramid_sa_testing/__init__.py
+++ b/testing/src/pyramid_sa_testing/__init__.py
@@ -5,14 +5,19 @@ import transaction
 import webtest
 from pyramid.scripting import prepare
 from sqlalchemy import create_engine
+from sqlalchemy.pool import NullPool
 
 from pyramid_sa import Base, get_tm_session
 
 
 @pytest.fixture(scope="session")
-def pyramid_sa_engine():
-    """SQLite in-memory engine. Override for PostgreSQL or other backends."""
-    engine = create_engine("sqlite://")
+def pyramid_sa_engine(postgresql_proc):
+    """PostgreSQL engine via pytest-postgresql. Override for other backends."""
+    url = (
+        f"postgresql+psycopg://{postgresql_proc.user}"
+        f":@{postgresql_proc.host}:{postgresql_proc.port}/postgres"
+    )
+    engine = create_engine(url, poolclass=NullPool)
     yield engine
     Base.metadata.drop_all(engine)
     engine.dispose()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from pyramid.config import Configurator
 from pyramid.scripting import prepare
 from sqlalchemy import String, create_engine
 from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.pool import NullPool
 
 from pyramid_sa import AuditMixin, Base, generate_uuid, get_tm_session
 
@@ -55,9 +56,18 @@ class TestSecurityPolicy:
         return []
 
 
+def _pg_engine(postgresql_proc, dbname: str = "postgres"):
+    """Create a PostgreSQL-backed SQLAlchemy engine from a postgresql_proc fixture."""
+    url = (
+        f"postgresql+psycopg://{postgresql_proc.user}"
+        f":@{postgresql_proc.host}:{postgresql_proc.port}/{dbname}"
+    )
+    return create_engine(url, poolclass=NullPool)
+
+
 @pytest.fixture(scope="session")
-def db_engine():
-    engine = create_engine("sqlite://")
+def db_engine(postgresql_proc):
+    engine = _pg_engine(postgresql_proc)
     Base.metadata.create_all(engine)
     yield engine
     Base.metadata.drop_all(engine)

--- a/tests/soft_delete/conftest.py
+++ b/tests/soft_delete/conftest.py
@@ -1,16 +1,31 @@
 """Fixtures for soft delete tests."""
 
+import psycopg
 import pytest
-from sqlalchemy import create_engine
 
 from pyramid_sa import Base
+from tests.conftest import _pg_engine
 from tests.soft_delete.app import create_app
 
 
 @pytest.fixture(scope="session")
-def db_engine():
-    """Bare engine — tables created after app config transforms constraints."""
-    engine = create_engine("sqlite://")
+def db_engine(postgresql_proc):
+    """Separate database — tables created after app config transforms constraints.
+
+    Soft-delete transforms unique constraints into partial indexes. A dedicated
+    database avoids conflicts with other test modules that create tables before
+    the transformation runs.
+    """
+    with psycopg.connect(
+        host=postgresql_proc.host,
+        port=postgresql_proc.port,
+        user=postgresql_proc.user,
+        dbname="postgres",
+        autocommit=True,
+    ) as conn:
+        conn.execute("CREATE DATABASE test_soft_delete")
+
+    engine = _pg_engine(postgresql_proc, dbname="test_soft_delete")
     yield engine
     Base.metadata.drop_all(engine)
     engine.dispose()

--- a/tests/tween/conftest.py
+++ b/tests/tween/conftest.py
@@ -1,15 +1,15 @@
 """Fixtures for default tween tests."""
 
 import pytest
-from sqlalchemy import create_engine
 
 from pyramid_sa import Base
+from tests.conftest import _pg_engine
 from tests.tween.app import create_app
 
 
 @pytest.fixture(scope="session")
-def db_engine():
-    engine = create_engine("sqlite://")
+def db_engine(postgresql_proc):
+    engine = _pg_engine(postgresql_proc)
     Base.metadata.create_all(engine)
     yield engine
     engine.dispose()

--- a/tests/tween_custom_errors/conftest.py
+++ b/tests/tween_custom_errors/conftest.py
@@ -1,15 +1,15 @@
 """Fixtures for custom error formatter tween tests."""
 
 import pytest
-from sqlalchemy import create_engine
+from tests.conftest import _pg_engine
 from tests.tween_custom_errors.app import create_app
 
 from pyramid_sa import Base
 
 
 @pytest.fixture(scope="session")
-def db_engine():
-    engine = create_engine("sqlite://")
+def db_engine(postgresql_proc):
+    engine = _pg_engine(postgresql_proc)
     Base.metadata.create_all(engine)
     yield engine
     engine.dispose()

--- a/tests/tween_partial_override/conftest.py
+++ b/tests/tween_partial_override/conftest.py
@@ -1,15 +1,15 @@
 """Fixtures for partial error formatter override tests."""
 
 import pytest
-from sqlalchemy import create_engine
+from tests.conftest import _pg_engine
 from tests.tween_partial_override.app import create_app
 
 from pyramid_sa import Base
 
 
 @pytest.fixture(scope="session")
-def db_engine():
-    engine = create_engine("sqlite://")
+def db_engine(postgresql_proc):
+    engine = _pg_engine(postgresql_proc)
     Base.metadata.create_all(engine)
     yield engine
     engine.dispose()

--- a/uv.lock
+++ b/uv.lock
@@ -349,6 +349,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mirakuru"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "psutil", marker = "sys_platform != 'cygwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/23/db9034ba28c7d89a540ffb8ca789f70dc12079108ece1cd1762295d5c807/mirakuru-3.0.2.tar.gz", hash = "sha256:21192186a8680ea7567ca68170261df3785768b12962dd19fe8cccab15ad3441", size = 29338, upload-time = "2026-02-11T19:41:15.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/5f/a3f1a7f1f6e55de9285b03ae7e0d3c2a15e044b6e3f9b53bef5609ca05f2/mirakuru-3.0.2-py3-none-any.whl", hash = "sha256:10e5dac4a8f26872c63e9cdfdc01b775aaa2beb3ced98abc497279d2dc525b8f", size = 27583, upload-time = "2026-02-11T19:41:13.578Z" },
+]
+
+[[package]]
 name = "mkdocs"
 version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -503,6 +515,55 @@ wheels = [
 ]
 
 [[package]]
+name = "port-for"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/a0/80a64e8cc096c7a9d0f546a28994af849b4775afc5e4ee44bf2739a55115/port_for-1.0.0.tar.gz", hash = "sha256:404d161b1b2c82e2f6b31d8646396b4847d02bf5ee10068c92b7263657a14582", size = 21681, upload-time = "2025-09-30T10:22:51.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/2c/b1faca65b9728b4ac43f0bee4bb9e7294bd0a62cc2ee59fd59403bf575f6/port_for-1.0.0-py3-none-any.whl", hash = "sha256:35a848b98cf4cc075fe80dc49ae5c3a78e3ca345a23bd39bf5252277b4eef5c2", size = 17544, upload-time = "2025-09-30T10:22:49.878Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -546,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "pyramid-sa"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -562,8 +623,10 @@ dependencies = [
 dev = [
     { name = "black" },
     { name = "mkdocs-material" },
+    { name = "psycopg" },
     { name = "pyramid-sa-testing" },
     { name = "pytest" },
+    { name = "pytest-postgresql" },
     { name = "ruff" },
     { name = "transaction" },
     { name = "waitress" },
@@ -585,8 +648,10 @@ requires-dist = [
 dev = [
     { name = "black" },
     { name = "mkdocs-material" },
+    { name = "psycopg" },
     { name = "pyramid-sa-testing", editable = "testing" },
     { name = "pytest" },
+    { name = "pytest-postgresql" },
     { name = "ruff" },
     { name = "transaction" },
     { name = "waitress" },
@@ -598,14 +663,18 @@ name = "pyramid-sa-testing"
 version = "0.1.0"
 source = { editable = "testing" }
 dependencies = [
+    { name = "psycopg" },
     { name = "pyramid-sa" },
+    { name = "pytest-postgresql" },
     { name = "transaction" },
     { name = "webtest" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "psycopg" },
     { name = "pyramid-sa", editable = "." },
+    { name = "pytest-postgresql" },
     { name = "transaction" },
     { name = "webtest" },
 ]
@@ -637,6 +706,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-postgresql"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mirakuru" },
+    { name = "packaging" },
+    { name = "port-for" },
+    { name = "psycopg" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/c8/b9607675904b3e4004c76109741aac6479daecfe6fb38ad89f330c6c5adc/pytest_postgresql-8.0.0.tar.gz", hash = "sha256:26cbd44a0adef76cf4a82a3a2263f0e029bc54b5863556a9bd86ca3edfa91cce", size = 49737, upload-time = "2026-01-23T21:14:34.554Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/cf/2c962ce63904e2b051b644a0036bdeeae8ae05d91e11e829b220c3db9935/pytest_postgresql-8.0.0-py3-none-any.whl", hash = "sha256:125b63b16d630c2dea19807062ed4c96e6123f06058ce65b82b4b14174d6c4b8", size = 40228, upload-time = "2026-01-23T21:14:33.08Z" },
 ]
 
 [[package]]
@@ -857,6 +942,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- All 61 tests now run against a real PostgreSQL instance via pytest-postgresql's `postgresql_proc` fixture
- Devcontainer Dockerfile installs PostgreSQL server binaries so tests are self-contained (no external service needed)
- Soft-delete tests use a dedicated database to avoid schema conflicts from metadata transformation ordering

Closes #15

## Test plan

- [x] All 61 tests pass against PostgreSQL (`uv run pytest -v`)
- [x] Ruff and Black checks pass
- [ ] Rebuild devcontainer to verify Dockerfile installs PostgreSQL correctly
- [ ] Verify `postgresql_proc` discovers `pg_ctl` via `pg_config --bindir`