### PR TITLE
Improve documentation coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 Pyramid SQLAlchemy Integration — a reusable library that wires SQLAlchemy into any Pyramid application.
 
+## Features
+
+- **Session management** — engine, transaction-managed sessions, `request.dbsession`
+- **Declarative base** — `Base` with naming conventions and utility methods (`as_dict`, `copy_with`)
+- **Audit trail** — opt-in `AuditMixin` tracking created/updated by whom and when
+- **Soft delete** — opt-in `SoftDeleteMixin` with query filtering, unique indexes, and safe restore
+- **Error mapping** — `NoResultFound` → 404, `IntegrityError` → 409, with customizable bodies
+- **JSON rendering** — `datetime`, `date`, `UUID` adapters out of the box
+- **Alembic scaffold** — `db init-alembic` for pre-wired migration setup
+- **CLI commands** — `db drop`, `db initialize` for schema management
+- **Test fixtures** — companion `pyramid-sa-testing` package with PostgreSQL-backed pytest plugin
+
+## Documentation
+
+Full documentation is available at the [docs site](docs/index.md), covering all features in detail.
+
 ## Installation
 
 ```bash
@@ -14,7 +30,7 @@ For test fixtures (dev only):
 pip install pyramid-sa-testing
 ```
 
-## Usage
+## Quick start
 
 In your Pyramid app factory:
 
@@ -29,13 +45,13 @@ def create_app(global_config=None, dbengine=None, **settings):
         config.registry["dbengine"] = dbengine
 
     config.include("pyramid_sa")
+    config.sa_enable_audit()          # optional: auto-populate audit fields
+    config.sa_enable_soft_delete()    # optional: soft-delete behavior
     config.sa_scan_models("myapp.models")
 
     config.scan(".views")
     return config.make_wsgi_app()
 ```
-
-`sa_scan_models` accepts one or more dotted module paths. It imports each module (registering models with `Base`) and calls `configure_mappers()` so all relationships are resolved.
 
 ### What `config.include("pyramid_sa")` does
 
@@ -44,40 +60,46 @@ def create_app(global_config=None, dbengine=None, **settings):
 3. Registers a session factory and adds `request.dbsession` as a reified property
 4. Adds an exception tween (`NoResultFound` → 404, `IntegrityError` → 409)
 5. Configures a JSON renderer with adapters for `datetime`, `date`, and `UUID`
-6. Registers the `sa_scan_models` directive on the Configurator
+6. Registers directives: `sa_scan_models`, `sa_enable_audit`, `sa_enable_soft_delete`, `sa_error_formatter`
 
-### Base model
+### Base vs Model
 
-All your models should inherit from `pyramid_sa.Base`:
+Use `Base` for plain models. Use `Model` for models that need both audit columns and soft-delete:
 
 ```python
-import uuid
-
-from sqlalchemy import String
-from sqlalchemy.orm import Mapped, mapped_column
-
-from pyramid_sa import Base, generate_uuid
+from pyramid_sa import Base, Model, generate_uuid
 
 
 class Item(Base):
+    """Plain model — no audit or soft-delete columns."""
+
     __tablename__ = "items"
 
     id: Mapped[int] = mapped_column(primary_key=True)
     uuid: Mapped[uuid.UUID] = mapped_column(default=generate_uuid, unique=True)
     name: Mapped[str] = mapped_column(String(255))
+
+
+class Article(Model):
+    """Audited + soft-deletable model."""
+
+    __tablename__ = "articles"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(String(255))
 ```
 
-`Base` includes an `AuditMixin` that adds `created_at`, `updated_at`, `created_by`, `updated_by`, `created_ip`, `updated_ip` columns automatically.
+See the [Models docs](docs/models.md) for `as_dict()`, `copy_with()`, and selective mixin usage.
 
 ### Alembic
 
-Scaffold alembic in your project with a single command:
+Scaffold alembic in your project:
 
 ```bash
 db init-alembic
 ```
 
-This creates `alembic.ini`, `alembic/env.py`, `alembic/script.py.mako`, and `alembic/versions/` in the current directory, pre-wired with pyramid-sa helpers. Then edit `alembic/env.py` to import your models:
+Then edit `alembic/env.py` to import your models:
 
 ```python
 from alembic import context
@@ -94,8 +116,6 @@ if context.is_offline_mode():
 else:
     run_migrations_online(target_metadata)
 ```
-
-Migration versions live in your app (`alembic/versions/`), never in the library.
 
 ### CLI
 
@@ -117,18 +137,15 @@ def cli(ctx, config_uri):
 cli.add_command(db)
 ```
 
-Commands:
-- `db init-alembic` — scaffold alembic in the current directory (`--force` to overwrite)
-- `db drop` — drop all database tables
-- `db initialize` — create schema (`--drop-before`, `--run-thru-alembic` flags)
+Commands: `db init-alembic`, `db drop`, `db initialize` (`--drop-before`, `--run-thru-alembic`).
 
 ## Test Fixtures
 
-Install `pyramid-sa-testing` and the pytest plugin is auto-discovered. It provides:
+Install `pyramid-sa-testing` and the pytest plugin is auto-discovered:
 
 | Fixture | Scope | Description |
 |---|---|---|
-| `pyramid_sa_engine` | session | SQLite in-memory engine (override for PostgreSQL) |
+| `pyramid_sa_engine` | session | PostgreSQL engine via pytest-postgresql |
 | `pyramid_sa_tm` | function | Doomed transaction manager — auto-rollback after each test |
 | `pyramid_sa_dbsession` | function | DB session bound to the test transaction |
 | `pyramid_sa_testapp` | function | WebTest TestApp with session injected |
@@ -149,6 +166,8 @@ def app(pyramid_sa_engine):
     Base.metadata.create_all(pyramid_sa_engine)
     return wsgi_app
 ```
+
+See the [Testing docs](docs/testing.md) for examples and advanced usage.
 
 ## Development
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,180 @@
+# API Reference
+
+Complete public API grouped by module. All items listed here are importable from their respective modules. Items marked with **top-level** are also importable directly from `pyramid_sa`.
+
+## `pyramid_sa`
+
+The top-level package re-exports the most commonly used names and provides the Pyramid entry point.
+
+### `includeme(config)`
+
+Pyramid entry point. Activate with `config.include("pyramid_sa")`. Wires engine, session factory, `request.dbsession`, exception tween, JSON renderer, and registers all directives.
+
+### `Model`
+
+**top-level** — `class Model(AuditMixin, SoftDeleteMixin, Base)`
+
+Abstract base class combining audit columns, soft-delete columns, and all `Base` utilities. Use for models that need both features.
+
+---
+
+## `pyramid_sa.meta`
+
+### `Base`
+
+**top-level** — `class Base(ORMClass, DeclarativeBase)`
+
+Declarative base with naming conventions and utility methods. All models should inherit from this (or from `Model`).
+
+### `ORMClass`
+
+Mixin class providing utility methods on all models.
+
+**`as_dict(hide_internal_fields=True, convert_to_camel=True, exclude=None) -> dict`**
+
+Convert instance to a dictionary. See [Base & Models](models.md#as_dict) for details.
+
+**`copy_with(**kwargs) -> Self`**
+
+Create a detached copy with optional field overrides. Excludes `id`, `uuid`, `created_at`, `updated_at`.
+
+### `generate_uuid() -> uuid.UUID`
+
+**top-level** — Returns a new UUID v4.
+
+---
+
+## `pyramid_sa.audit`
+
+### `AuditMixin`
+
+**top-level** — Mixin adding audit columns: `created_at`, `updated_at`, `created_by`, `updated_by`, `created_ip`, `updated_ip`.
+
+### `sa_enable_audit(config) -> None`
+
+**top-level** — Pyramid directive. Registers `before_insert` and `before_update` event listeners that populate audit fields from `request.authenticated_userid` and `request.client_addr`.
+
+---
+
+## `pyramid_sa.soft_delete`
+
+### `SoftDeleteMixin`
+
+**top-level** — Mixin adding soft-delete columns and instance methods.
+
+**Columns:** `deleted_at` (DateTime), `deleted_by` (String(40)), `deleted_ip` (String(40))
+
+**`is_deleted -> bool`** (property)
+
+Returns `True` if `deleted_at` is not `None`.
+
+**`soft_delete() -> None`**
+
+Mark the instance as soft-deleted. Sets `deleted_at`, `deleted_by`, and `deleted_ip` from the request.
+
+**`can_restore() -> list[tuple[str, ...]]`**
+
+Check for unique constraint conflicts before restoring. Returns a list of conflicting column groups (empty = safe to restore).
+
+**`restore() -> None`**
+
+Clear `deleted_at`, `deleted_by`, and `deleted_ip`. Raises `RestoreConflictError` if an active row conflicts.
+
+### `SoftDeleteSession`
+
+**top-level** — `class SoftDeleteSession(Session)`
+
+Session subclass used by pyramid-sa's session factory.
+
+**`hard_delete(instance) -> None`**
+
+Perform a real SQL DELETE, bypassing soft-delete interception.
+
+### `SoftDeleteUniqueIndex(*columns, name=None)`
+
+**top-level** — `class SoftDeleteUniqueIndex(Index)`
+
+Partial unique index for `__table_args__`. Creates `WHERE deleted_at IS NULL` unique index on the specified columns. Validates that the model has `SoftDeleteMixin`.
+
+### `soft_delete_mapped_column(*args, unique=False, **kwargs) -> MappedColumn`
+
+**top-level** — Like `mapped_column` but `unique=True` creates a soft-delete-aware partial unique index instead of a plain unique constraint.
+
+### `RestoreConflictError`
+
+**top-level** — `class RestoreConflictError(Exception)`
+
+Raised by `restore()` when an active row conflicts with the soft-deleted row's unique values.
+
+**Attributes:**
+
+- `instance` — the model instance that cannot be restored
+- `conflicts` — list of column-name tuples, e.g. `[("slug",)]` or `[("tenant_id", "code")]`
+
+### `sa_enable_soft_delete(config) -> None`
+
+**top-level** — Pyramid directive. Registers event listeners for delete interception, query filtering, and index finalization on the app's sessionmaker.
+
+---
+
+## `pyramid_sa.session`
+
+### `get_engine(settings, prefix="sqlalchemy.") -> Engine`
+
+**top-level** — Create a SQLAlchemy engine from the `{prefix}url` key in settings.
+
+### `get_session_factory(engine) -> sessionmaker[SoftDeleteSession]`
+
+**top-level** — Create a session factory bound to the engine, using `SoftDeleteSession`.
+
+### `get_tm_session(session_factory, transaction_manager, request=None) -> SoftDeleteSession`
+
+**top-level** — Create a transaction-managed session. Registers the session with zope.sqlalchemy and stores the request in `session.info["request"]`.
+
+---
+
+## `pyramid_sa.tween`
+
+### `sa_error_formatter(config, *, not_found=None, conflict=None) -> None`
+
+**top-level** — Pyramid directive. Configure custom error body formatters for the exception tween. Each formatter is `(request) -> dict`.
+
+### `default_not_found_body(request) -> dict`
+
+**top-level** — Returns `{"error": "not_found", "message": "Resource not found."}`.
+
+### `default_conflict_body(request) -> dict`
+
+**top-level** — Returns `{"error": "conflict", "message": "Operation violates a uniqueness constraint."}`.
+
+### `exception_tween_factory(handler, registry) -> Callable`
+
+Tween factory that catches `NoResultFound` (→ 404) and `IntegrityError` (→ 409).
+
+---
+
+## `pyramid_sa.renderer`
+
+### `configure_json_renderer(config) -> None`
+
+Register a JSON renderer with adapters for `datetime` (→ ISO string), `date` (→ ISO string), and `UUID` (→ string).
+
+---
+
+## `pyramid_sa.scripts.cli`
+
+### `db`
+
+Click command group for database management. Contains `init-alembic`, `drop`, and `initialize` subcommands. See [Database & Migrations](database.md) for usage.
+
+---
+
+## `pyramid_sa.scripts.alembic`
+
+### `run_migrations_offline(target_metadata) -> None`
+
+Run Alembic migrations in offline mode (SQL output only).
+
+### `run_migrations_online(target_metadata) -> None`
+
+Run Alembic migrations in online mode (direct database connection).

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,0 +1,68 @@
+# Audit Trail
+
+`AuditMixin` adds columns to track who created and updated each record and when. The columns are always present on models that use the mixin; the *behavior* (auto-populating fields from the request) is activated separately via a Pyramid directive.
+
+## Columns
+
+| Column | Type | Set on |
+|---|---|---|
+| `created_at` | `DateTime` | Insert (default: `datetime.now(UTC)`) |
+| `updated_at` | `DateTime` | Update (via `onupdate`) |
+| `created_by` | `String(40)` | Insert (from `request.authenticated_userid`) |
+| `updated_by` | `String(40)` | Update (from `request.authenticated_userid`) |
+| `created_ip` | `String(40)` | Insert (from `request.client_addr`) |
+| `updated_ip` | `String(40)` | Update (from `request.client_addr`) |
+
+## Usage
+
+### Adding audit columns to a model
+
+Use `AuditMixin` directly or inherit from `Model` (which includes it):
+
+```python
+from pyramid_sa import Base
+from pyramid_sa.audit import AuditMixin
+
+
+class Item(AuditMixin, Base):
+    __tablename__ = "items"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(255))
+```
+
+Or use `Model` which bundles `AuditMixin` + `SoftDeleteMixin` + `Base`:
+
+```python
+from pyramid_sa import Model
+
+
+class Item(Model):
+    __tablename__ = "items"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(255))
+```
+
+### Activating automatic field population
+
+The columns exist on the model regardless, but to have `created_by`, `updated_by`, `created_ip`, and `updated_ip` populated automatically from the request, call the directive in your app factory:
+
+```python
+config.include("pyramid_sa")
+config.sa_enable_audit()
+```
+
+This registers `before_insert` and `before_update` event listeners on the SQLAlchemy mapper. The listeners:
+
+1. Check if the target model is an `AuditMixin` instance
+2. Read `request.authenticated_userid` from the session's `info["request"]`
+3. Set `created_by`/`updated_by` (truncated to 40 chars) and `created_ip`/`updated_ip`
+
+## Columns vs behavior
+
+Mixins provide **columns** at import time. Directives activate **behavior** at app startup.
+
+A model can have `AuditMixin` columns without calling `sa_enable_audit()`. In that case, `created_at` and `updated_at` still work (they use SQLAlchemy's `default` and `onupdate`), but `created_by`, `updated_by`, `created_ip`, and `updated_ip` will remain `NULL` unless you set them manually.
+
+This separation is intentional — it allows shared schemas where some apps populate audit fields and others don't.

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,97 @@
+# Database & Migrations
+
+pyramid-sa provides CLI commands for database management and bundled Alembic templates for migration scaffolding.
+
+## CLI commands
+
+The `db` command group is a Click group that you compose into your app's CLI:
+
+```python
+import click
+from pyramid_sa.scripts.cli import db
+
+
+@click.group()
+@click.option("--config-uri", default="development.ini", show_default=True)
+@click.pass_context
+def cli(ctx, config_uri):
+    ctx.ensure_object(dict)
+    ctx.obj["config_uri"] = config_uri
+
+
+cli.add_command(db)
+```
+
+### `db init-alembic`
+
+Scaffold Alembic in the current directory, pre-wired for pyramid-sa:
+
+```bash
+db init-alembic
+```
+
+This creates:
+
+- `alembic.ini` — Alembic configuration
+- `alembic/env.py` — migration environment, pre-wired with pyramid-sa helpers
+- `alembic/script.py.mako` — migration script template
+- `alembic/versions/` — directory for migration files
+
+The command refuses to overwrite existing files unless `--force` is passed:
+
+```bash
+db init-alembic --force
+```
+
+### `db drop`
+
+Drop all database tables:
+
+```bash
+db --config-uri production.ini drop
+```
+
+Uses `Base.metadata.drop_all()` on the engine bootstrapped from the Pyramid config.
+
+### `db initialize`
+
+Create the database schema:
+
+```bash
+db initialize
+```
+
+Options:
+
+| Flag | Description |
+|---|---|
+| `--drop-before` | Drop all tables before creating the schema |
+| `--run-thru-alembic` | Apply Alembic migrations (`alembic upgrade head`) instead of `metadata.create_all()` |
+
+```bash
+db initialize --drop-before --run-thru-alembic
+```
+
+## Alembic setup
+
+After running `db init-alembic`, edit `alembic/env.py` to import your models so Alembic autogenerate can see them:
+
+```python
+from alembic import context
+
+from pyramid_sa import Base
+from pyramid_sa.scripts.alembic import run_migrations_offline, run_migrations_online
+
+import myapp.models  # noqa: F401
+
+target_metadata = Base.metadata
+
+if context.is_offline_mode():
+    run_migrations_offline(target_metadata)
+else:
+    run_migrations_online(target_metadata)
+```
+
+The migration helpers (`run_migrations_offline`, `run_migrations_online`) handle engine creation from `alembic.ini` and context configuration.
+
+Migration versions live in your app (`alembic/versions/`), never in the library. This keeps library upgrades safe — your migration history is fully under your control.

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,52 @@
+# Error Handling
+
+pyramid-sa includes an exception tween that translates common SQLAlchemy exceptions into HTTP error responses with JSON bodies. The tween is registered automatically when you call `config.include("pyramid_sa")`.
+
+## Default behavior
+
+| Exception | HTTP Status | Default body |
+|---|---|---|
+| `sqlalchemy.orm.exc.NoResultFound` | 404 Not Found | `{"error": "not_found", "message": "Resource not found."}` |
+| `sqlalchemy.exc.IntegrityError` | 409 Conflict | `{"error": "conflict", "message": "Operation violates a uniqueness constraint."}` |
+
+The tween sits below `excview_tween_factory` so normal Pyramid HTTP exceptions still work as expected. Any exception not listed above propagates unchanged.
+
+## Custom error formatters
+
+To match your API's error schema, override the default bodies with `sa_error_formatter`:
+
+```python
+def my_not_found(request):
+    return {"code": "NOT_FOUND", "detail": "The requested resource does not exist."}
+
+
+def my_conflict(request):
+    return {"code": "CONFLICT", "detail": "A record with this value already exists."}
+
+
+config.include("pyramid_sa")
+config.sa_error_formatter(not_found=my_not_found, conflict=my_conflict)
+```
+
+Each formatter is a callable with signature `(request) -> dict`. The returned dict becomes the `json_body` of the HTTP error response.
+
+### Partial overrides
+
+Both arguments are optional. You can override just one:
+
+```python
+config.sa_error_formatter(not_found=my_not_found)
+# conflict keeps the default body
+```
+
+### Access to request context
+
+Since formatters receive the current request, you can use any request-scoped data:
+
+```python
+def localized_not_found(request):
+    return {
+        "error": "not_found",
+        "message": request.localizer.translate("Resource not found."),
+    }
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,100 @@
+# Getting Started
+
+## Installation
+
+```bash
+pip install pyramid-sa
+```
+
+For test fixtures (dev only):
+
+```bash
+pip install pyramid-sa-testing
+```
+
+## App factory
+
+In your Pyramid application factory, include `pyramid_sa` and scan your model modules:
+
+```python
+from pyramid.config import Configurator
+
+
+def create_app(global_config=None, dbengine=None, **settings):
+    config = Configurator(settings=settings)
+
+    if dbengine is not None:
+        config.registry["dbengine"] = dbengine
+
+    config.include("pyramid_sa")
+    config.sa_scan_models("myapp.models")
+
+    config.scan(".views")
+    return config.make_wsgi_app()
+```
+
+`sa_scan_models` accepts one or more dotted module paths. It imports each module (registering models with `Base`) and calls `configure_mappers()` so all relationships are resolved.
+
+## What `config.include("pyramid_sa")` does
+
+1. Includes `pyramid_tm` (transaction management)
+2. Creates the SQLAlchemy engine from `sqlalchemy.url` in settings (or uses `config.registry["dbengine"]` if pre-set)
+3. Registers a session factory and adds `request.dbsession` as a reified property
+4. Adds an exception tween (`NoResultFound` → 404, `IntegrityError` → 409)
+5. Configures a JSON renderer with adapters for `datetime`, `date`, and `UUID`
+6. Registers directives on the Configurator:
+    - `sa_scan_models` — import model modules and configure mappers
+    - `sa_enable_audit` — activate [audit trail](audit.md) event listeners
+    - `sa_enable_soft_delete` — activate [soft-delete](soft-delete.md) behavior
+    - `sa_error_formatter` — customize [error response bodies](error-handling.md)
+
+## First model
+
+All models should inherit from `pyramid_sa.Base`:
+
+```python
+import uuid
+
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from pyramid_sa import Base, generate_uuid
+
+
+class Item(Base):
+    __tablename__ = "items"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    uuid: Mapped[uuid.UUID] = mapped_column(default=generate_uuid, unique=True)
+    name: Mapped[str] = mapped_column(String(255))
+```
+
+`Base` includes `ORMClass`, which gives every model `as_dict()` and `copy_with()` methods. See [Base & Models](models.md) for details.
+
+For models that need audit columns and soft-delete support, use `Model` instead:
+
+```python
+from pyramid_sa import Model
+
+
+class Article(Model):
+    __tablename__ = "articles"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(String(255))
+```
+
+`Model` combines `AuditMixin` + `SoftDeleteMixin` + `Base` for the common case. See [Base & Models](models.md) for guidance on when to use each.
+
+## Enabling optional features
+
+After `config.include("pyramid_sa")`, activate the features your app needs:
+
+```python
+config.include("pyramid_sa")
+config.sa_enable_audit()          # populate audit fields from request
+config.sa_enable_soft_delete()    # intercept deletes, filter queries
+config.sa_scan_models("myapp.models")
+```
+
+Each directive is opt-in — your app only gets the behavior it asks for.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,4 +2,37 @@
 
 Pyramid SQLAlchemy Integration — a reusable library that wires SQLAlchemy into any Pyramid application via `config.include("pyramid_sa")`.
 
-See the [README](https://github.com/sensetek/pyramid-sa) for full usage documentation.
+## Features
+
+- **Session management** — engine creation, transaction-managed sessions via pyramid_tm + zope.sqlalchemy, `request.dbsession` as a reified property
+- **Declarative base** — `Base` with consistent naming conventions and utility methods (`as_dict`, `copy_with`) on every model
+- **Audit trail** — opt-in `AuditMixin` that tracks `created_at`, `updated_at`, `created_by`, `updated_by`, `created_ip`, `updated_ip`
+- **Soft delete** — opt-in `SoftDeleteMixin` with automatic query filtering, delete interception, partial unique indexes, and safe restore
+- **Error mapping** — exception tween that translates `NoResultFound` to 404 and `IntegrityError` to 409, with customizable error bodies
+- **JSON rendering** — adapters for `datetime`, `date`, and `UUID` out of the box
+- **Alembic scaffold** — `db init-alembic` command copies pre-wired templates into your project
+- **CLI commands** — `db drop` and `db initialize` for schema management
+- **Test fixtures** — companion `pyramid-sa-testing` package with a pytest plugin for PostgreSQL-backed test sessions
+
+## Quick install
+
+```bash
+pip install pyramid-sa
+```
+
+For test fixtures (dev only):
+
+```bash
+pip install pyramid-sa-testing
+```
+
+## Where to go next
+
+- [Getting Started](getting-started.md) — installation, app factory, first model
+- [Base & Models](models.md) — `Base`, `Model`, `ORMClass` utilities
+- [Audit Trail](audit.md) — automatic created/updated tracking
+- [Soft Delete](soft-delete.md) — soft-delete behavior, unique indexes, restore
+- [Error Handling](error-handling.md) — exception tween and custom formatters
+- [Database & Migrations](database.md) — Alembic scaffold and CLI commands
+- [Testing](testing.md) — pytest fixtures for database testing
+- [API Reference](api.md) — complete public API

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,0 +1,128 @@
+# Base & Models
+
+pyramid-sa provides two base classes for your models: `Base` and `Model`. Both include utility methods from `ORMClass`.
+
+## Base
+
+`Base` is a SQLAlchemy `DeclarativeBase` with consistent naming conventions and utility methods:
+
+```python
+from pyramid_sa import Base
+```
+
+All models inheriting from `Base` get:
+
+- **Naming conventions** for indexes, constraints, and foreign keys (compatible with Alembic autogenerate)
+- **`as_dict()`** and **`copy_with()`** utility methods via `ORMClass`
+
+Use `Base` when you want a plain model without audit or soft-delete columns.
+
+### Naming conventions
+
+| Type | Pattern | Example |
+|---|---|---|
+| Primary key | `pk_%(table_name)s` | `pk_items` |
+| Unique constraint | `uq_%(table_name)s_%(column_0_name)s` | `uq_items_uuid` |
+| Index | `ix_%(column_0_label)s` | `ix_items_name` |
+| Foreign key | `fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s` | `fk_orders_user_id_users` |
+| Check constraint | `ck_%(table_name)s_%(constraint_name)s` | `ck_items_positive_price` |
+
+## Model
+
+`Model` is a convenience base class that combines `AuditMixin` + `SoftDeleteMixin` + `Base`:
+
+```python
+from pyramid_sa import Model
+
+
+class Article(Model):
+    __tablename__ = "articles"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(String(255))
+```
+
+This gives your model audit columns (`created_at`, `updated_at`, etc.) and soft-delete columns (`deleted_at`, `deleted_by`, `deleted_ip`) automatically. See [Audit Trail](audit.md) and [Soft Delete](soft-delete.md) for details.
+
+## When to use `Base` vs `Model`
+
+| Scenario | Use |
+|---|---|
+| Model needs both audit tracking and soft-delete | `Model` |
+| Model needs only audit columns | `Base` + `AuditMixin` |
+| Model needs only soft-delete columns | `Base` + `SoftDeleteMixin` |
+| Plain model with no extras | `Base` |
+
+Example with selective mixins:
+
+```python
+from pyramid_sa import Base
+from pyramid_sa.audit import AuditMixin
+
+
+class LogEntry(AuditMixin, Base):
+    """Audited but not soft-deletable."""
+
+    __tablename__ = "log_entries"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    message: Mapped[str] = mapped_column(String(500))
+```
+
+## ORMClass utilities
+
+Every model inheriting from `Base` (or `Model`) gets these methods from `ORMClass`.
+
+### `as_dict()`
+
+Convert a model instance to a dictionary:
+
+```python
+item = dbsession.get(Item, 1)
+data = item.as_dict()
+```
+
+Parameters:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `hide_internal_fields` | `bool` | `True` | Removes `id`, renames `uuid` to `id` |
+| `convert_to_camel` | `bool` | `True` | Converts snake_case keys to camelCase |
+| `exclude` | `list[str] \| None` | `None` | Column names to exclude |
+
+With defaults, `as_dict()` produces API-friendly output:
+
+```python
+item.as_dict()
+# {"id": "550e8400-...", "name": "Widget", "createdAt": "2024-01-15T...", ...}
+
+item.as_dict(hide_internal_fields=False, convert_to_camel=False)
+# {"id": 1, "uuid": "550e8400-...", "name": "Widget", "created_at": "2024-01-15T...", ...}
+```
+
+### `copy_with()`
+
+Create a detached copy of a model instance with optional field overrides:
+
+```python
+original = dbsession.get(Item, 1)
+clone = original.copy_with(name="Widget v2")
+dbsession.add(clone)
+```
+
+The copy excludes `id`, `uuid`, `created_at`, and `updated_at` — the new instance gets fresh values for these.
+
+## `generate_uuid()`
+
+A convenience function that returns a new `uuid.UUID` (v4), useful as a column default:
+
+```python
+from pyramid_sa import Base, generate_uuid
+
+
+class Item(Base):
+    __tablename__ = "items"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    uuid: Mapped[uuid.UUID] = mapped_column(default=generate_uuid, unique=True)
+```

--- a/docs/soft-delete.md
+++ b/docs/soft-delete.md
@@ -1,0 +1,207 @@
+# Soft Delete
+
+Soft delete marks rows as deleted instead of removing them from the database. pyramid-sa provides a mixin for columns, a session subclass for hard deletes, partial unique indexes for value reuse, and safe restore with conflict detection.
+
+## Setup
+
+### Adding soft-delete columns
+
+Use `SoftDeleteMixin` directly or inherit from `Model` (which includes it):
+
+```python
+from pyramid_sa import Base
+from pyramid_sa import SoftDeleteMixin
+
+
+class Article(SoftDeleteMixin, Base):
+    __tablename__ = "articles"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(String(255))
+```
+
+This adds three columns:
+
+| Column | Type | Description |
+|---|---|---|
+| `deleted_at` | `DateTime` | When the row was soft-deleted (`None` = active) |
+| `deleted_by` | `String(40)` | Who deleted it (from `request.authenticated_userid`) |
+| `deleted_ip` | `String(40)` | Client IP at deletion time |
+
+### Activating soft-delete behavior
+
+The columns alone don't change how SQLAlchemy handles deletes or queries. To activate the behavior, call the directive in your app factory:
+
+```python
+config.include("pyramid_sa")
+config.sa_enable_soft_delete()
+config.sa_scan_models("myapp.models")
+```
+
+This registers event listeners for:
+
+- **Delete interception** — `session.delete(obj)` sets `deleted_at` instead of issuing SQL DELETE
+- **Query filtering** — SELECT queries automatically exclude rows where `deleted_at IS NOT NULL`
+- **Index finalization** — `SoftDeleteUniqueIndex` and `soft_delete_mapped_column(unique=True)` are converted into partial unique indexes
+
+## Soft-deleting a record
+
+There are two ways to soft-delete:
+
+### Via `session.delete()`
+
+When `sa_enable_soft_delete()` is active, calling `session.delete()` on a `SoftDeleteMixin` model performs a soft delete:
+
+```python
+article = dbsession.get(Article, 1)
+dbsession.delete(article)
+# article.deleted_at is now set; the row stays in the database
+```
+
+The `deleted_by` and `deleted_ip` fields are populated from the request automatically.
+
+### Via `soft_delete()` method
+
+You can also call the instance method directly:
+
+```python
+article = dbsession.get(Article, 1)
+article.soft_delete()
+```
+
+This sets `deleted_at`, `deleted_by`, and `deleted_ip` from the request. Unlike `session.delete()`, this is an explicit update — useful when you want to soft-delete without going through the session's delete machinery.
+
+## Checking delete status
+
+```python
+article.is_deleted  # True if deleted_at is not None
+```
+
+## Query filtering
+
+When `sa_enable_soft_delete()` is active, all SELECT queries automatically exclude soft-deleted rows:
+
+```python
+# Only returns articles where deleted_at IS NULL
+articles = dbsession.scalars(select(Article)).all()
+```
+
+### Including deleted rows
+
+Use the `include_deleted` execution option to bypass the filter:
+
+```python
+from sqlalchemy import select
+
+stmt = select(Article).execution_options(include_deleted=True)
+all_articles = dbsession.scalars(stmt).all()
+```
+
+## Hard delete
+
+To permanently remove a row from the database, use `hard_delete()` on the session:
+
+```python
+article = dbsession.get(Article, 1)
+dbsession.hard_delete(article)
+# Row is actually deleted via SQL DELETE
+```
+
+This bypasses the soft-delete interception. The session is a `SoftDeleteSession` subclass that adds this method. Non-soft-delete models are always hard-deleted by `session.delete()`.
+
+## Unique indexes
+
+Soft-deleted rows can block reuse of unique values (e.g., a slug or email). pyramid-sa provides two APIs to create partial unique indexes that only constrain active rows (`WHERE deleted_at IS NULL`).
+
+### `soft_delete_mapped_column` — single column
+
+For single-column uniqueness at the column level:
+
+```python
+from pyramid_sa import Model, soft_delete_mapped_column
+
+
+class Article(Model):
+    __tablename__ = "articles"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    slug: Mapped[str] = soft_delete_mapped_column(String(255), unique=True)
+    uuid: Mapped[str] = mapped_column(unique=True)  # stays globally unique
+```
+
+`soft_delete_mapped_column(unique=True)` creates a partial unique index. Regular `mapped_column(unique=True)` remains globally unique — you choose per column.
+
+### `SoftDeleteUniqueIndex` — multi-column
+
+For composite uniqueness in `__table_args__`:
+
+```python
+from pyramid_sa import Model, SoftDeleteUniqueIndex
+
+
+class ScopedArticle(Model):
+    __tablename__ = "scoped_articles"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(40))
+    slug: Mapped[str] = mapped_column(String(255))
+
+    __table_args__ = (SoftDeleteUniqueIndex("tenant_id", "slug"),)
+```
+
+Both produce indexes named `uq_{table}_{cols}_active` with `WHERE deleted_at IS NULL`.
+
+### Warning for plain unique constraints
+
+When `sa_enable_soft_delete()` runs, it logs a warning if it finds a plain `UniqueConstraint` on a soft-delete model. This nudges you to choose explicitly between global uniqueness (keep `mapped_column(unique=True)`) and soft-delete-aware uniqueness (use `soft_delete_mapped_column(unique=True)` or `SoftDeleteUniqueIndex`).
+
+## Restoring soft-deleted rows
+
+### `restore()`
+
+Un-delete a soft-deleted instance:
+
+```python
+stmt = select(Article).execution_options(include_deleted=True).where(Article.id == 1)
+article = dbsession.scalars(stmt).one()
+article.restore()
+# deleted_at, deleted_by, deleted_ip are all cleared
+```
+
+If restoring would violate a partial unique constraint (another active row holds the same value), `restore()` raises `RestoreConflictError`:
+
+```python
+from pyramid_sa import RestoreConflictError
+
+try:
+    article.restore()
+except RestoreConflictError as exc:
+    print(exc.conflicts)  # [("slug",)] or [("tenant_id", "slug")]
+    print(exc.instance)   # the article that can't be restored
+```
+
+### `can_restore()`
+
+Check for conflicts before attempting to restore:
+
+```python
+conflicts = article.can_restore()
+if not conflicts:
+    article.restore()
+else:
+    # conflicts is a list of column-name tuples, e.g. [("slug",)]
+    print(f"Cannot restore: conflicts on {conflicts}")
+```
+
+`can_restore()` queries for active rows with matching unique values. It returns an empty list when restore is safe.
+
+## Columns vs behavior
+
+Like [audit](audit.md), soft-delete separates columns from behavior:
+
+- `SoftDeleteMixin` provides **columns** at import time
+- `config.sa_enable_soft_delete()` activates **behavior** at app startup
+
+A model can have the soft-delete columns without the behavior if the directive is never called. Queries won't be filtered and `session.delete()` will perform real deletes.
+
+Soft-delete event listeners are registered on the specific `sessionmaker` instance, not the global `Session` class. This scoping prevents behavior from leaking across apps in the same process — important in test suites that create multiple Pyramid apps.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,111 @@
+# Testing
+
+The `pyramid-sa-testing` companion package provides a pytest plugin with fixtures for database-backed tests. It is auto-discovered via the `pytest11` entry point — no manual registration needed.
+
+## Installation
+
+```bash
+pip install pyramid-sa-testing
+```
+
+This is a dev-only dependency. It pulls in `webtest`, `transaction`, `pytest-postgresql`, and `psycopg`.
+
+## Fixtures
+
+| Fixture | Scope | Description |
+|---|---|---|
+| `pyramid_sa_engine` | session | PostgreSQL engine via pytest-postgresql. Starts a temporary PostgreSQL process on a random port. |
+| `pyramid_sa_tm` | function | Doomed transaction manager — auto-rollback after each test |
+| `pyramid_sa_dbsession` | function | Database session bound to the test transaction |
+| `pyramid_sa_testapp` | function | WebTest `TestApp` with the test session injected |
+| `pyramid_sa_app_request` | function | Real Pyramid request (via `pyramid.scripting.prepare`) for service-layer testing |
+
+## Required `app` fixture
+
+Your `conftest.py` must provide a session-scoped `app` fixture that creates your Pyramid WSGI application and initializes the schema:
+
+```python
+import pytest
+from pyramid_sa import Base
+
+
+@pytest.fixture(scope="session")
+def app(pyramid_sa_engine):
+    from myapp.app import create_app
+
+    wsgi_app = create_app(dbengine=pyramid_sa_engine)
+    Base.metadata.create_all(pyramid_sa_engine)
+    return wsgi_app
+```
+
+The plugin fixtures depend on `app` to access `app.registry["dbsession_factory"]`.
+
+## Test isolation
+
+Each test runs inside a doomed transaction. The `pyramid_sa_tm` fixture:
+
+1. Begins a new transaction
+2. Immediately dooms it (marks for rollback)
+3. Yields the transaction manager to the test
+4. Aborts the transaction after the test completes
+
+This means every database change made during a test is rolled back automatically — no cleanup needed.
+
+## Usage examples
+
+### Testing views with `pyramid_sa_testapp`
+
+```python
+def test_list_items(pyramid_sa_testapp, pyramid_sa_dbsession):
+    pyramid_sa_dbsession.add(Item(name="Widget"))
+    pyramid_sa_dbsession.flush()
+
+    response = pyramid_sa_testapp.get("/items", status=200)
+    assert len(response.json) == 1
+```
+
+### Testing services with `pyramid_sa_app_request`
+
+```python
+def test_create_item(pyramid_sa_app_request, pyramid_sa_dbsession):
+    request = pyramid_sa_app_request
+    request.dbsession = pyramid_sa_dbsession
+
+    item = create_item(request, name="Widget")
+    assert item.name == "Widget"
+    assert item.created_by is not None
+```
+
+### Testing with `pyramid_sa_dbsession` directly
+
+```python
+def test_soft_delete(pyramid_sa_dbsession):
+    item = Item(name="Widget")
+    pyramid_sa_dbsession.add(item)
+    pyramid_sa_dbsession.flush()
+
+    pyramid_sa_dbsession.delete(item)
+    pyramid_sa_dbsession.flush()
+
+    assert item.is_deleted
+```
+
+## PostgreSQL by default
+
+`pyramid_sa_engine` uses pytest-postgresql to start a temporary PostgreSQL server. This ensures tests run against real PostgreSQL behavior (partial indexes, constraint semantics, etc.).
+
+The devcontainer includes PostgreSQL server binaries so `postgresql_proc` can start its own instance. For CI environments, ensure PostgreSQL is available or override `pyramid_sa_engine` to use a different backend.
+
+### Overriding the engine
+
+To use a different database for tests, override `pyramid_sa_engine` in your `conftest.py`:
+
+```python
+@pytest.fixture(scope="session")
+def pyramid_sa_engine():
+    from sqlalchemy import create_engine
+
+    engine = create_engine("sqlite:///:memory:")
+    yield engine
+    engine.dispose()
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,15 @@
 site_name: pyramid-sa
+site_description: Pyramid SQLAlchemy Integration
+repo_url: https://github.com/sensetek/pyramid-sa
 theme:
   name: material
 nav:
   - Home: index.md
+  - Getting Started: getting-started.md
+  - Base & Models: models.md
+  - Audit Trail: audit.md
+  - Soft Delete: soft-delete.md
+  - Error Handling: error-handling.md
+  - Database & Migrations: database.md
+  - Testing: testing.md
+  - API Reference: api.md


### PR DESCRIPTION
## Summary

- Built comprehensive MkDocs documentation site with 8 new pages covering all features: getting started, base/models, audit trail, soft delete, error handling, database/migrations, testing, and API reference
- Updated README with features list, Base vs Model guidance, directive examples, and links to docs
- Updated mkdocs.yml with full navigation structure

Closes #21

## Test plan

- [x] `mkdocs build --strict` succeeds with no warnings
- [x] All 74 tests pass
- [x] `ruff check` and `black --check` pass
- [ ] Review each docs page for accuracy against source code
- [ ] Verify internal links between docs pages work in MkDocs serve