### PR TITLE
Refactor: move audit and soft_delete into models subpackage

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -44,7 +44,7 @@ Create a detached copy with optional field overrides. Excludes `id`, `uuid`, `cr
 
 ---
 
-## `pyramid_sa.audit`
+## `pyramid_sa.models.audit`
 
 ### `AuditMixin`
 
@@ -56,7 +56,7 @@ Create a detached copy with optional field overrides. Excludes `id`, `uuid`, `cr
 
 ---
 
-## `pyramid_sa.soft_delete`
+## `pyramid_sa.models.soft_delete`
 
 ### `SoftDeleteMixin`
 

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -21,7 +21,7 @@ Use `AuditMixin` directly or inherit from `Model` (which includes it):
 
 ```python
 from pyramid_sa import Base
-from pyramid_sa.audit import AuditMixin
+from pyramid_sa.models.audit import AuditMixin
 
 
 class Item(AuditMixin, Base):

--- a/docs/models.md
+++ b/docs/models.md
@@ -57,7 +57,7 @@ Example with selective mixins:
 
 ```python
 from pyramid_sa import Base
-from pyramid_sa.audit import AuditMixin
+from pyramid_sa.models.audit import AuditMixin
 
 
 class LogEntry(AuditMixin, Base):

--- a/knowledge/architecture.md
+++ b/knowledge/architecture.md
@@ -6,10 +6,12 @@ pyramid-sa is a Pyramid integration library that provides SQLAlchemy session man
 
 ## Components
 
-- **__init__.py** — `includeme` (Pyramid entry point), `sa_scan_models` directive, `Model` convenience base class (AuditMixin + SoftDeleteMixin + Base)
-- **meta.py** — `ORMClass` (utility methods: `as_dict`, `copy_with`), `Base` (DeclarativeBase + ORMClass), naming conventions, `generate_uuid`, `_now`
-- **audit.py** — `AuditMixin` (audit columns), `before_insert`/`before_update` event listeners, `sa_enable_audit` directive
-- **soft_delete.py** — `SoftDeleteMixin` (soft-delete columns + `soft_delete()`/`restore()`/`is_deleted`/`can_restore()`), `SoftDeleteSession` (`hard_delete()`), `SoftDeleteUniqueIndex` (partial unique index for `__table_args__`), `soft_delete_mapped_column` (column-level partial unique index), `RestoreConflictError`, event listeners (delete interception, query filtering, index finalization), `sa_enable_soft_delete` directive
+- **__init__.py** — `includeme` (Pyramid entry point), `sa_scan_models` directive, top-level re-exports
+- **meta.py** — `ORMClass` (utility methods: `as_dict`, `copy_with`), `Base` (DeclarativeBase + ORMClass), naming conventions
+- **utils.py** — Shared helpers: `_now` (UTC timestamp), `generate_uuid` (UUID v4)
+- **models/__init__.py** — `Model` convenience base class (AuditMixin + SoftDeleteMixin + Base), re-exports from audit and soft_delete submodules
+- **models/audit.py** — `AuditMixin` (audit columns), `before_insert`/`before_update` event listeners, `sa_enable_audit` directive
+- **models/soft_delete.py** — `SoftDeleteMixin` (soft-delete columns + `soft_delete()`/`restore()`/`is_deleted`/`can_restore()`), `SoftDeleteSession` (`hard_delete()`), `SoftDeleteUniqueIndex` (partial unique index for `__table_args__`), `soft_delete_mapped_column` (column-level partial unique index), `RestoreConflictError`, event listeners (delete interception, query filtering, index finalization), `sa_enable_soft_delete` directive
 - **session.py** — Engine creation, session factory (uses `SoftDeleteSession`), transaction-managed sessions via pyramid_tm + zope.sqlalchemy
 - **tween.py** — Exception tween translating `NoResultFound` → 404 and `IntegrityError` → 409, with configurable error body formatters via `sa_error_formatter` directive
 - **renderer.py** — JSON renderer with adapters for datetime, date, UUID

--- a/src/pyramid_sa/__init__.py
+++ b/src/pyramid_sa/__init__.py
@@ -4,38 +4,26 @@ import importlib
 
 from sqlalchemy.orm import configure_mappers
 
-from pyramid_sa.audit import AuditMixin, sa_enable_audit
-from pyramid_sa.meta import Base, generate_uuid
-from pyramid_sa.renderer import configure_json_renderer
-from pyramid_sa.session import get_engine, get_session_factory, get_tm_session
-from pyramid_sa.soft_delete import (
+from pyramid_sa.meta import Base
+from pyramid_sa.models import (
+    AuditMixin,
+    Model,
     RestoreConflictError,
     SoftDeleteMixin,
     SoftDeleteSession,
     SoftDeleteUniqueIndex,
+    sa_enable_audit,
     sa_enable_soft_delete,
     soft_delete_mapped_column,
 )
+from pyramid_sa.renderer import configure_json_renderer
+from pyramid_sa.session import get_engine, get_session_factory, get_tm_session
 from pyramid_sa.tween import (
     default_conflict_body,
     default_not_found_body,
     sa_error_formatter,
 )
-
-
-class Model(AuditMixin, SoftDeleteMixin, Base):
-    """Auditable, soft-deletable base class — the common case.
-
-    Use instead of ``Base`` when the model needs both audit columns and
-    soft-delete support::
-
-        class Article(Model):
-            __tablename__ = "articles"
-            ...
-    """
-
-    __abstract__ = True
-
+from pyramid_sa.utils import generate_uuid
 
 __all__ = [
     "AuditMixin",

--- a/src/pyramid_sa/meta.py
+++ b/src/pyramid_sa/meta.py
@@ -1,7 +1,4 @@
-"""SQLAlchemy declarative base and utility helpers."""
-
-import uuid
-from datetime import UTC, datetime
+"""SQLAlchemy declarative base and ORM utility methods."""
 
 from camel_converter import dict_to_camel
 from sqlalchemy import MetaData, inspect
@@ -14,14 +11,6 @@ NAMING_CONVENTION = {
     "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
     "pk": "pk_%(table_name)s",
 }
-
-
-def _now() -> datetime:
-    return datetime.now(UTC)
-
-
-def generate_uuid() -> uuid.UUID:
-    return uuid.uuid4()
 
 
 class ORMClass:

--- a/src/pyramid_sa/models/__init__.py
+++ b/src/pyramid_sa/models/__init__.py
@@ -1,0 +1,39 @@
+"""Model mixins, helpers, and the convenience Model base class."""
+
+from pyramid_sa.meta import Base
+from pyramid_sa.models.audit import AuditMixin, sa_enable_audit
+from pyramid_sa.models.soft_delete import (
+    RestoreConflictError,
+    SoftDeleteMixin,
+    SoftDeleteSession,
+    SoftDeleteUniqueIndex,
+    sa_enable_soft_delete,
+    soft_delete_mapped_column,
+)
+
+
+class Model(AuditMixin, SoftDeleteMixin, Base):
+    """Auditable, soft-deletable base class — the common case.
+
+    Use instead of ``Base`` when the model needs both audit columns and
+    soft-delete support::
+
+        class Article(Model):
+            __tablename__ = "articles"
+            ...
+    """
+
+    __abstract__ = True
+
+
+__all__ = [
+    "AuditMixin",
+    "Model",
+    "RestoreConflictError",
+    "SoftDeleteMixin",
+    "SoftDeleteSession",
+    "SoftDeleteUniqueIndex",
+    "sa_enable_audit",
+    "sa_enable_soft_delete",
+    "soft_delete_mapped_column",
+]

--- a/src/pyramid_sa/models/audit.py
+++ b/src/pyramid_sa/models/audit.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from sqlalchemy import DateTime, String, event, inspect
 from sqlalchemy.orm import Mapped, Mapper, mapped_column
 
-from pyramid_sa.meta import _now
+from pyramid_sa.utils import _now
 
 
 class AuditMixin:

--- a/src/pyramid_sa/models/soft_delete.py
+++ b/src/pyramid_sa/models/soft_delete.py
@@ -1,7 +1,7 @@
 """Soft delete mixin, session subclass, and Pyramid directive."""
 
 import logging
-from datetime import UTC, datetime
+from datetime import datetime
 
 from sqlalchemy import (
     DateTime,
@@ -23,6 +23,7 @@ from sqlalchemy.orm import (
 )
 
 from pyramid_sa.meta import Base
+from pyramid_sa.utils import _now
 
 logger = logging.getLogger(__name__)
 
@@ -30,10 +31,6 @@ _HARD_DELETE_FLAG = "_pyramid_sa_hard_delete"
 _ACTIVE_INDEX_SUFFIX = "_active"
 
 _soft_delete_models: set[type] = set()
-
-
-def _now() -> datetime:
-    return datetime.now(UTC)
 
 
 class SoftDeleteUniqueIndex(Index):

--- a/src/pyramid_sa/session.py
+++ b/src/pyramid_sa/session.py
@@ -4,7 +4,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from zope.sqlalchemy import register
 
-from pyramid_sa.soft_delete import SoftDeleteSession
+from pyramid_sa.models.soft_delete import SoftDeleteSession
 
 
 def get_engine(settings: dict, prefix: str = "sqlalchemy."):

--- a/src/pyramid_sa/utils.py
+++ b/src/pyramid_sa/utils.py
@@ -1,0 +1,12 @@
+"""Shared utility helpers."""
+
+import uuid
+from datetime import UTC, datetime
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def generate_uuid() -> uuid.UUID:
+    return uuid.uuid4()

--- a/tests/soft_delete/test_restore_conflict.py
+++ b/tests/soft_delete/test_restore_conflict.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from pyramid_sa.soft_delete import RestoreConflictError
+from pyramid_sa.models.soft_delete import RestoreConflictError
 from tests.soft_delete.app.models import Article, ScopedArticle
 
 

--- a/tests/soft_delete/test_soft_delete_index.py
+++ b/tests/soft_delete/test_soft_delete_index.py
@@ -7,7 +7,10 @@ from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from pyramid_sa import Base, SoftDeleteUniqueIndex, soft_delete_mapped_column
-from pyramid_sa.soft_delete import _ACTIVE_INDEX_SUFFIX
+from pyramid_sa.models.soft_delete import (
+    _ACTIVE_INDEX_SUFFIX,
+    _warn_plain_unique_constraints,
+)
 from tests.soft_delete.app.models import Article, ScopedArticle
 
 
@@ -52,9 +55,7 @@ def test_plain_unique_stays_global(app):
 
 def test_plain_unique_constraint_warns(caplog):
     """A plain UniqueConstraint on a soft-delete model logs a warning."""
-    from pyramid_sa.soft_delete import _warn_plain_unique_constraints
-
-    with caplog.at_level(logging.WARNING, logger="pyramid_sa.soft_delete"):
+    with caplog.at_level(logging.WARNING, logger="pyramid_sa.models.soft_delete"):
         _warn_plain_unique_constraints(Article)
 
     assert any("uuid" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary

- Moved `audit.py` and `soft_delete.py` into a `models/` subpackage for clearer package organization
- Created `utils.py` with shared `_now()` and `generate_uuid()` helpers, eliminating the duplicate `_now()` that existed in both `meta.py` and `soft_delete.py`
- Moved the `Model` convenience class from `__init__.py` into `models/__init__.py`
- Updated all internal imports, test imports, docs, and knowledge files

The top-level public API (`from pyramid_sa import ...`) is unchanged.

Closes #25

## Test plan

- [x] All 74 existing tests pass
- [x] Linter and formatter pass with no errors
- [x] `from pyramid_sa import AuditMixin, SoftDeleteMixin, Model, ...` still works
- [x] `from pyramid_sa.models.audit import AuditMixin` works
- [x] `from pyramid_sa.models.soft_delete import SoftDeleteMixin` works