### PR TITLE
Bugs and improvements from production codebase comparison (v0.8.0)

### DIFF
--- a/knowledge/architecture.md
+++ b/knowledge/architecture.md
@@ -23,14 +23,15 @@ pyramid-sa is a Pyramid integration library that provides SQLAlchemy session man
 ## Data Flow
 
 1. Consuming app calls `config.include("pyramid_sa")`
-2. `includeme` wires pyramid_tm, engine, session factory, tween, renderer, and registers directives (`sa_scan_models`, `sa_enable_audit`, `sa_enable_soft_delete`, `sa_error_formatter`)
-3. App calls `config.sa_enable_audit()` to activate audit event listeners
-4. App calls `config.sa_enable_soft_delete()` to activate soft-delete behavior (query filtering, delete interception, index finalization for `SoftDeleteUniqueIndex` and `soft_delete_mapped_column`)
-5. App calls `config.sa_scan_models("myapp.models")` to import model modules and configure mappers
-6. Each request gets a `request.dbsession` (reified, transaction-managed)
-7. Audit event listeners populate created_by/updated_by from the request
-8. Soft-delete event listeners intercept `session.delete()` and filter queries
-9. On exceptions, the tween maps SA errors to HTTP responses
+2. `includeme` wires pyramid_tm, pyramid_retry, engine, session factory, tweens (exception mapping + request-session wiring), and registers directives (`sa_json_renderer`, `sa_scan_models`, `sa_enable_audit`, `sa_enable_soft_delete`, `sa_error_formatter`)
+3. App calls `config.sa_json_renderer()` to register the JSON renderer (opt-in)
+4. App calls `config.sa_enable_audit()` to activate audit event listeners
+5. App calls `config.sa_enable_soft_delete()` to activate soft-delete behavior (query filtering, delete interception, index finalization for `SoftDeleteUniqueIndex` and `soft_delete_mapped_column`)
+6. App calls `config.sa_scan_models("myapp.models")` to import model modules and configure mappers (accepts strings or module objects)
+7. Each request gets a `request.dbsession` (reified, transaction-managed); the request-session tween ensures `dbsession.info["request"]` is always set
+8. Audit event listeners populate created_by/updated_by/created_ip/updated_ip from the request
+9. Soft-delete event listeners intercept `session.delete()` and filter queries
+10. On exceptions, the tween maps SA errors to HTTP responses; formatters receive the exception via `exc` keyword
 
 ## Columns vs Behavior
 
@@ -50,8 +51,16 @@ The `pyramid_sa_testing` plugin provides `pyramid_sa_engine` (backed by `postgre
 
 The devcontainer Dockerfile installs PostgreSQL server binaries so `postgresql_proc` can start its own instance.
 
+## Timezone Handling
+
+`_now()` in `utils.py` uses `datetime.UTC` (Python 3.11+) to produce timezone-aware UTC datetimes. The `tzinfo` is `datetime.timezone.utc`. This compares equal to `pytz.UTC` but has a different `repr`. Projects migrating from naive datetimes (`TIMESTAMP WITHOUT TIME ZONE`) should ensure column types use `TIMESTAMP(timezone=True)` or cast existing data.
+
+## Testing Plugin Override Points
+
+The `pyramid_sa_engine` fixture is the intended override point for projects that use a different PostgreSQL driver or test infrastructure. Override it in your `conftest.py` to yield a SQLAlchemy `Engine` instance and handle cleanup (e.g., `drop_all`, `dispose`). All other plugin fixtures (`pyramid_sa_tm`, `pyramid_sa_dbsession`, `pyramid_sa_testapp`, `pyramid_sa_app_request`) build on top of the engine and the `app` fixture.
+
 ## External Dependencies
 
-pyramid, sqlalchemy, alembic, pyramid-tm, zope-sqlalchemy, click, camel-converter
+pyramid, sqlalchemy, alembic, pyramid-tm, pyramid-retry, zope-sqlalchemy, click, camel-converter
 
 Dev/test: pytest-postgresql, psycopg

--- a/knowledge/decisions.md
+++ b/knowledge/decisions.md
@@ -119,3 +119,22 @@ Use this format when adding a new decision:
 **Decision**: Replace the magic transformation with two explicit APIs the developer imports and uses: `SoftDeleteUniqueIndex(*columns)` for multi-column unique indexes in `__table_args__`, and `soft_delete_mapped_column(..., unique=True)` for single-column uniqueness at the column level. Both produce partial unique indexes with `WHERE deleted_at IS NULL`. A warning is logged when a plain `UniqueConstraint` is detected on a soft-delete model, nudging the developer to choose explicitly. `SoftDeleteUniqueIndex` validates at table creation time that the model has a `deleted_at` column (from `SoftDeleteMixin`), raising `TypeError` if not. Regular `mapped_column(unique=True)` stays globally unique — the developer chooses per-column.
 
 **Consequences**: Explicit is better than implicit. Developers opt in per-column, so globally unique columns (UUIDs, external IDs) are no longer silently transformed. `can_restore()` continues to work because both APIs produce indexes named `uq_{table}_{cols}_active`. This is a breaking change — consuming apps must update their models to use the new APIs. The warning helps catch missed columns during migration.
+
+### 2026-03-31 — Bugs and improvements from production comparison (v0.8.0)
+
+**Status**: Accepted
+
+**Context**: Comparing pyramid-sa v0.8.0 against battle-tested production patterns revealed several bugs and improvement opportunities.
+
+**Decision**: Applied the following changes:
+
+- **B1**: `get_engine` now uses `engine_from_config` instead of `create_engine(url)`, so all `sqlalchemy.*` INI keys (pool_size, pool_recycle, echo, etc.) are honoured.
+- **B2**: Added a request-session tween (`_add_request_to_session_tween_factory`) that sets `request.dbsession.info["request"] = request` on every request, ensuring audit listeners work even when sessions are injected via `request.environ["app.dbsession"]`.
+- **B3**: Testing plugin fixtures now set `REMOTE_ADDR` and wire `dbsession.info["request"]` so audit fields populate correctly in tests.
+- **B4**: JSON renderer is now opt-in via `config.sa_json_renderer()` directive instead of being registered unconditionally. **Breaking change** — consuming apps must call the directive explicitly.
+- **I1**: `pyramid_retry` is now included by default for transient DB error handling. Added to dependencies.
+- **I2**: `includeme` checks both `config.registry` and `settings` for a pre-configured `"dbengine"`.
+- **I3**: `sa_scan_models` accepts both dotted string paths and module objects.
+- **I6**: Error body formatters now receive the caught exception via `exc` keyword argument. Default formatters accept `**kwargs` for backwards compatibility.
+
+**Consequences**: B4 is a breaking change for consuming apps that relied on the auto-registered renderer. I6 requires existing custom formatters to accept `**kwargs` or an `exc` keyword. All other changes are backwards-compatible.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "sqlalchemy>=2.0",
     "alembic",
     "pyramid-tm>=2.6",
+    "pyramid-retry",
     "zope-sqlalchemy>=4.1",
     "click>=8.1",
     "camel-converter>=3.0",

--- a/src/pyramid_sa/__init__.py
+++ b/src/pyramid_sa/__init__.py
@@ -1,6 +1,7 @@
 """Pyramid SQLAlchemy Integration."""
 
 import importlib
+from types import ModuleType
 
 from sqlalchemy.orm import configure_mappers
 
@@ -33,6 +34,7 @@ __all__ = [
     "SoftDeleteMixin",
     "SoftDeleteSession",
     "SoftDeleteUniqueIndex",
+    "configure_json_renderer",
     "default_conflict_body",
     "default_not_found_body",
     "generate_uuid",
@@ -46,23 +48,43 @@ __all__ = [
 ]
 
 
-def _scan_models_directive(config: object, *module_paths: str) -> None:
+def _scan_models_directive(config: object, *module_paths: str | ModuleType) -> None:
     """Import model modules and configure SQLAlchemy mappers.
 
-    Accepts one or more dotted Python module paths.  Each module is imported
-    (which registers its models with ``Base``), then ``configure_mappers()``
+    Accepts one or more dotted Python module paths or already-imported module
+    objects.  Each string path is imported (which registers its models with
+    ``Base``); module objects are accepted as-is.  Then ``configure_mappers()``
     is called once so that all relationships are resolved.
 
     Usage::
 
         config.include("pyramid_sa")
         config.sa_scan_models("myapp.models")
+
+        import myapp.models
+        config.sa_scan_models(myapp.models)
     """
     if not module_paths:
         raise ValueError("sa_scan_models requires at least one module path")
     for path in module_paths:
-        importlib.import_module(path)
+        if not isinstance(path, ModuleType):
+            importlib.import_module(path)
     configure_mappers()
+
+
+def _add_request_to_session_tween_factory(handler, registry):
+    """Ensure ``request.dbsession.info["request"]`` is always set.
+
+    Without this tween, sessions injected via ``request.environ["app.dbsession"]``
+    (the standard test path) would lack the request reference, causing audit
+    listeners to silently skip field population.
+    """
+
+    def tween(request):
+        request.dbsession.info["request"] = request
+        return handler(request)
+
+    return tween
 
 
 def includeme(config):
@@ -72,8 +94,9 @@ def includeme(config):
     """
     settings = config.get_settings()
     config.include("pyramid_tm")
+    config.include("pyramid_retry")
 
-    engine = config.registry.get("dbengine")
+    engine = config.registry.get("dbengine") or settings.get("dbengine")
     if engine is None:
         engine = get_engine(settings)
 
@@ -91,9 +114,12 @@ def includeme(config):
         "pyramid_sa.tween.exception_tween_factory",
         under="pyramid.tweens.excview_tween_factory",
     )
+    config.add_tween(
+        "pyramid_sa._add_request_to_session_tween_factory",
+        under="pyramid_sa.tween.exception_tween_factory",
+    )
 
-    configure_json_renderer(config)
-
+    config.add_directive("sa_json_renderer", configure_json_renderer)
     config.add_directive("sa_scan_models", _scan_models_directive)
     config.add_directive("sa_enable_audit", sa_enable_audit)
     config.add_directive("sa_enable_soft_delete", sa_enable_soft_delete)

--- a/src/pyramid_sa/session.py
+++ b/src/pyramid_sa/session.py
@@ -1,6 +1,6 @@
 """SQLAlchemy engine and session management for Pyramid."""
 
-from sqlalchemy import create_engine
+from sqlalchemy import engine_from_config
 from sqlalchemy.orm import sessionmaker
 from zope.sqlalchemy import register
 
@@ -8,7 +8,7 @@ from pyramid_sa.models.soft_delete import SoftDeleteSession
 
 
 def get_engine(settings: dict, prefix: str = "sqlalchemy."):
-    return create_engine(settings[f"{prefix}url"])
+    return engine_from_config(settings, prefix)
 
 
 def get_session_factory(engine) -> sessionmaker[SoftDeleteSession]:

--- a/src/pyramid_sa/tween.py
+++ b/src/pyramid_sa/tween.py
@@ -10,18 +10,18 @@ from sqlalchemy.orm.exc import NoResultFound
 
 log = logging.getLogger(__name__)
 
-ErrorBodyFormatter = Callable[[Any], dict[str, Any]]
+ErrorBodyFormatter = Callable[..., dict[str, Any]]
 
 _REGISTRY_KEY_NOT_FOUND = "sa.error_formatter.not_found"
 _REGISTRY_KEY_CONFLICT = "sa.error_formatter.conflict"
 
 
-def default_not_found_body(request: Any) -> dict[str, Any]:
+def default_not_found_body(request: Any, **kwargs: Any) -> dict[str, Any]:
     """Return the default 404 error body."""
     return {"error": "not_found", "message": "Resource not found."}
 
 
-def default_conflict_body(request: Any) -> dict[str, Any]:
+def default_conflict_body(request: Any, **kwargs: Any) -> dict[str, Any]:
     """Return the default 409 error body."""
     return {
         "error": "conflict",
@@ -37,16 +37,21 @@ def sa_error_formatter(
 ) -> None:
     """Configure custom error body formatters for the exception tween.
 
-    Each formatter is a callable that receives the current request and returns
-    a dict used as the ``json_body`` of the HTTP error response.
+    Each formatter is a callable that receives the current request and
+    the caught exception (as ``exc`` keyword argument), and returns a dict
+    used as the ``json_body`` of the HTTP error response.
 
     Usage::
 
-        def my_not_found(request):
+        def my_not_found(request, **kwargs):
             return {"code": "NOT_FOUND", "detail": "Resource not found."}
 
+        def my_conflict(request, exc=None, **kwargs):
+            detail = str(exc.orig) if exc else "Duplicate entry."
+            return {"code": "CONFLICT", "detail": detail}
+
         config.include("pyramid_sa")
-        config.sa_error_formatter(not_found=my_not_found)
+        config.sa_error_formatter(not_found=my_not_found, conflict=my_conflict)
     """
     if not_found is not None:
         config.registry[_REGISTRY_KEY_NOT_FOUND] = not_found
@@ -66,14 +71,14 @@ def exception_tween_factory(handler: Any, registry: Any) -> Callable:
     def exception_tween(request: Any) -> Any:
         try:
             return handler(request)
-        except NoResultFound:
+        except NoResultFound as exc:
             raise HTTPNotFound(
-                json_body=not_found_formatter(request),
+                json_body=not_found_formatter(request, exc=exc),
             ) from None
         except IntegrityError as exc:
             log.warning("Integrity error: %s", exc.orig)
             raise HTTPConflict(
-                json_body=conflict_formatter(request),
+                json_body=conflict_formatter(request, exc=exc),
             ) from exc
 
     return exception_tween

--- a/src/pyramid_sa/utils.py
+++ b/src/pyramid_sa/utils.py
@@ -5,6 +5,15 @@ from datetime import UTC, datetime
 
 
 def _now() -> datetime:
+    """Return the current UTC time as a timezone-aware datetime.
+
+    Uses ``datetime.UTC`` (Python 3.11+).  The returned ``tzinfo`` is
+    ``datetime.timezone.utc``, which compares equal to ``pytz.UTC`` for
+    equality checks but produces a different ``repr``.  Projects migrating
+    from naive datetimes (PostgreSQL ``TIMESTAMP WITHOUT TIME ZONE``) should
+    ensure their column types match — use ``TIMESTAMP(timezone=True)`` or
+    cast existing data to avoid mixed-offset comparisons.
+    """
     return datetime.now(UTC)
 
 

--- a/testing/src/pyramid_sa_testing/__init__.py
+++ b/testing/src/pyramid_sa_testing/__init__.py
@@ -47,6 +47,7 @@ def pyramid_sa_testapp(app, pyramid_sa_tm, pyramid_sa_dbsession):
         app,
         extra_environ={
             "HTTP_HOST": "example.com",
+            "REMOTE_ADDR": "127.0.0.1",
             "tm.active": True,
             "tm.manager": pyramid_sa_tm,
             "app.dbsession": pyramid_sa_dbsession,
@@ -62,6 +63,7 @@ def pyramid_sa_app_request(app, pyramid_sa_tm, pyramid_sa_dbsession):
         request.host = "example.com"
         request.environ.update(
             {
+                "REMOTE_ADDR": "127.0.0.1",
                 "tm.active": True,
                 "tm.manager": pyramid_sa_tm,
                 "app.dbsession": pyramid_sa_dbsession,
@@ -69,4 +71,5 @@ def pyramid_sa_app_request(app, pyramid_sa_tm, pyramid_sa_dbsession):
         )
         request.dbsession = pyramid_sa_dbsession
         request.tm = pyramid_sa_tm
+        pyramid_sa_dbsession.info["request"] = request
         yield request

--- a/tests/cli/app/__init__.py
+++ b/tests/cli/app/__init__.py
@@ -8,6 +8,7 @@ def create_app(dbengine=None, **settings):
     if dbengine is not None:
         config.registry["dbengine"] = dbengine
     config.include("pyramid_sa")
+    config.sa_json_renderer()
     config.sa_enable_audit()
     config.sa_scan_models("tests.cli.app.models")
     return config.make_wsgi_app()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,7 @@ def build_app(db_engine):
         config = Configurator(settings={})
         config.registry["dbengine"] = db_engine
         config.include("pyramid_sa")
+        config.sa_json_renderer()
         config.sa_enable_audit()
         config.set_security_policy(TestSecurityPolicy())
         if configure is not None:

--- a/tests/includeme/test_includeme.py
+++ b/tests/includeme/test_includeme.py
@@ -9,6 +9,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm.exc import NoResultFound
 
 from pyramid_sa import Base
+from pyramid_sa.session import get_engine
 
 
 def test_registers_dbsession_factory():
@@ -32,6 +33,17 @@ def test_uses_pre_set_dbengine():
     assert factory.kw["bind"] is engine
 
 
+def test_uses_dbengine_from_settings():
+    """Verify includeme picks up an engine passed through settings."""
+    engine = create_engine("sqlite://")
+    config = Configurator(settings={"dbengine": engine})
+    config.include("pyramid_sa")
+    config.commit()
+
+    factory = config.registry["dbsession_factory"]
+    assert factory.kw["bind"] is engine
+
+
 def test_request_dbsession_via_webtest():
     """Verify requests have a dbsession attribute after includeme."""
     engine = create_engine("sqlite://")
@@ -40,6 +52,7 @@ def test_request_dbsession_via_webtest():
     config = Configurator(settings={})
     config.registry["dbengine"] = engine
     config.include("pyramid_sa")
+    config.sa_json_renderer()
     config.add_route("check", "/check")
     config.add_view(
         lambda request: {"has_dbsession": hasattr(request, "dbsession")},
@@ -72,9 +85,10 @@ def test_exception_tween_returns_404_for_not_found():
 
 
 def test_json_renderer_handles_datetime():
-    """Verify the JSON renderer serializes datetime to ISO-8601."""
+    """Verify sa_json_renderer serializes datetime to ISO-8601."""
     config = Configurator(settings={"sqlalchemy.url": "sqlite://"})
     config.include("pyramid_sa")
+    config.sa_json_renderer()
     config.add_route("time", "/time")
     config.add_view(
         lambda request: {"ts": datetime.datetime(2026, 3, 21, 12, 0, 0)},
@@ -86,6 +100,34 @@ def test_json_renderer_handles_datetime():
 
     response = testapp.get("/time")
     assert response.json["ts"] == "2026-03-21T12:00:00"
+
+
+def test_sa_json_renderer_registers_directive():
+    """Verify includeme registers the sa_json_renderer directive."""
+    config = Configurator(settings={"sqlalchemy.url": "sqlite://"})
+    config.include("pyramid_sa")
+
+    assert hasattr(config, "sa_json_renderer")
+
+
+def test_pyramid_retry_is_included():
+    """Verify includeme includes pyramid_retry for transient error handling."""
+    engine = create_engine("sqlite://")
+    config = Configurator(settings={})
+    config.registry["dbengine"] = engine
+    config.include("pyramid_sa")
+    config.sa_json_renderer()
+    config.add_route("check", "/check")
+    config.add_view(
+        lambda request: {"attempts": request.environ.get("retry.attempts")},
+        route_name="check",
+        renderer="json",
+    )
+    app = config.make_wsgi_app()
+    testapp_client = webtest.TestApp(app)
+
+    response = testapp_client.get("/check")
+    assert response.json["attempts"] is not None
 
 
 def test_sa_scan_models_registers_directive():
@@ -115,6 +157,17 @@ def test_sa_scan_models_accepts_multiple_paths():
     assert "items" in Base.metadata.tables
 
 
+def test_sa_scan_models_accepts_module_object():
+    """Verify sa_scan_models accepts an already-imported module object."""
+    import tests.cli.app.models as models_mod
+
+    config = Configurator(settings={"sqlalchemy.url": "sqlite://"})
+    config.include("pyramid_sa")
+    config.sa_scan_models(models_mod)
+
+    assert "books" in Base.metadata.tables
+
+
 def test_sa_scan_models_raises_on_no_args():
     """Verify sa_scan_models raises ValueError when called without arguments."""
     config = Configurator(settings={"sqlalchemy.url": "sqlite://"})
@@ -131,6 +184,17 @@ def test_sa_scan_models_raises_on_bad_module():
 
     with pytest.raises(ModuleNotFoundError):
         config.sa_scan_models("nonexistent.module")
+
+
+def test_get_engine_reads_all_settings():
+    """Verify get_engine passes all sqlalchemy.* INI keys to the engine."""
+    settings = {
+        "sqlalchemy.url": "sqlite://",
+        "sqlalchemy.echo": "true",
+    }
+    engine = get_engine(settings)
+    assert engine.echo is True
+    engine.dispose()
 
 
 def test_sa_enable_audit_registers_directive():

--- a/tests/renderer/conftest.py
+++ b/tests/renderer/conftest.py
@@ -12,6 +12,7 @@ def renderer_app():
     """Pyramid Configurator with pyramid_sa included, ready for route registration."""
     config = Configurator(settings={"sqlalchemy.url": "sqlite://"})
     config.include("pyramid_sa")
+    config.sa_json_renderer()
     return config
 
 

--- a/tests/testing/test_testing.py
+++ b/tests/testing/test_testing.py
@@ -8,6 +8,7 @@ from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from pyramid_sa import Base, generate_uuid
+from tests.conftest import Item
 
 
 class Widget(Base):
@@ -44,6 +45,19 @@ def test_testapp_makes_requests(pyramid_sa_testapp):
 def test_app_request_has_dbsession(pyramid_sa_app_request):
     """Verify the app request object has a dbsession attribute."""
     assert pyramid_sa_app_request.dbsession is not None
+
+
+def test_app_request_wires_audit_fields(pyramid_sa_app_request):
+    """Verify audit fields are populated via the plugin app_request fixture."""
+    pyramid_sa_app_request.environ["test.userid"] = "plugin-user"
+    dbsession = pyramid_sa_app_request.dbsession
+
+    item = Item(name="audit-test")
+    dbsession.add(item)
+    dbsession.flush()
+
+    assert item.created_by == "plugin-user"
+    assert item.created_ip == "127.0.0.1"
 
 
 def test_dbsession_rolls_back_between_tests(pyramid_sa_dbsession):

--- a/tests/tween/app/__init__.py
+++ b/tests/tween/app/__init__.py
@@ -27,6 +27,7 @@ def create_app(dbengine=None, **settings):
     if dbengine is not None:
         config.registry["dbengine"] = dbengine
     config.include("pyramid_sa")
+    config.sa_json_renderer()
 
     config.add_route("not_found", "/not-found")
     config.add_view(_view_not_found, route_name="not_found", renderer="json")

--- a/tests/tween_custom_errors/app/__init__.py
+++ b/tests/tween_custom_errors/app/__init__.py
@@ -5,12 +5,20 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
 
-def custom_not_found_body(request):
-    return {"code": "NOT_FOUND", "detail": "Nothing here."}
+def custom_not_found_body(request, exc=None, **kwargs):
+    return {
+        "code": "NOT_FOUND",
+        "detail": "Nothing here.",
+        "has_exc": exc is not None,
+    }
 
 
-def custom_conflict_body(request):
-    return {"code": "CONFLICT", "detail": "Duplicate entry."}
+def custom_conflict_body(request, exc=None, **kwargs):
+    return {
+        "code": "CONFLICT",
+        "detail": str(exc.orig) if exc else "Duplicate entry.",
+        "has_exc": exc is not None,
+    }
 
 
 def _view_not_found(request):
@@ -26,6 +34,7 @@ def create_app(dbengine=None, **settings):
     if dbengine is not None:
         config.registry["dbengine"] = dbengine
     config.include("pyramid_sa")
+    config.sa_json_renderer()
     config.sa_error_formatter(
         not_found=custom_not_found_body,
         conflict=custom_conflict_body,

--- a/tests/tween_custom_errors/test_custom_errors.py
+++ b/tests/tween_custom_errors/test_custom_errors.py
@@ -4,24 +4,22 @@ import webtest
 
 
 def test_not_found_uses_custom_formatter(app):
-    """Verify NoResultFound uses the app-configured custom body."""
+    """Verify NoResultFound uses the app-configured custom body with exc."""
     testapp = webtest.TestApp(app)
     response = testapp.get("/not-found", expect_errors=True)
 
     assert response.status_int == 404
-    assert response.json == {
-        "code": "NOT_FOUND",
-        "detail": "Nothing here.",
-    }
+    assert response.json["code"] == "NOT_FOUND"
+    assert response.json["detail"] == "Nothing here."
+    assert response.json["has_exc"] is True
 
 
 def test_conflict_uses_custom_formatter(app):
-    """Verify IntegrityError uses the app-configured custom body."""
+    """Verify IntegrityError uses the app-configured custom body with exc."""
     testapp = webtest.TestApp(app)
     response = testapp.get("/conflict", expect_errors=True)
 
     assert response.status_int == 409
-    assert response.json == {
-        "code": "CONFLICT",
-        "detail": "Duplicate entry.",
-    }
+    assert response.json["code"] == "CONFLICT"
+    assert response.json["detail"] == "duplicate key"
+    assert response.json["has_exc"] is True

--- a/tests/tween_partial_override/app/__init__.py
+++ b/tests/tween_partial_override/app/__init__.py
@@ -5,7 +5,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
 
-def custom_not_found_body(request):
+def custom_not_found_body(request, **kwargs):
     return {"code": "NOT_FOUND", "detail": "Custom 404."}
 
 
@@ -22,6 +22,7 @@ def create_app(dbengine=None, **settings):
     if dbengine is not None:
         config.registry["dbengine"] = dbengine
     config.include("pyramid_sa")
+    config.sa_json_renderer()
     config.sa_error_formatter(not_found=custom_not_found_body)
 
     config.add_route("not_found", "/not-found")

--- a/uv.lock
+++ b/uv.lock
@@ -691,6 +691,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyramid-retry"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyramid" },
+    { name = "zope-interface" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/02/2a084e7bc8ca3c50b67c6a6d58598c5771d93399e9ff2aadf6aa29c1adcc/pyramid_retry-2.1.1.tar.gz", hash = "sha256:baa8276ae68babad09e5f2f94efc4f7421f3b8fb526151df522052f8cd3ec0c9", size = 23266, upload-time = "2020-03-21T21:01:06.9Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/a7/b04390f36dcd0b117e023e4f980d6173da893b3c27f8b12ecd5dcc6fdb95/pyramid_retry-2.1.1-py2.py3-none-any.whl", hash = "sha256:b5129a60eb9d7409234ea52839006426d2ae887b4a1f0530c75ec336cabf2476", size = 6641, upload-time = "2020-03-21T21:01:05.701Z" },
+]
+
+[[package]]
 name = "pyramid-sa"
 version = "0.8.0"
 source = { editable = "." }
@@ -699,6 +712,7 @@ dependencies = [
     { name = "camel-converter" },
     { name = "click" },
     { name = "pyramid" },
+    { name = "pyramid-retry" },
     { name = "pyramid-tm" },
     { name = "sqlalchemy" },
     { name = "zope-sqlalchemy" },
@@ -724,6 +738,7 @@ requires-dist = [
     { name = "camel-converter", specifier = ">=3.0" },
     { name = "click", specifier = ">=8.1" },
     { name = "pyramid" },
+    { name = "pyramid-retry" },
     { name = "pyramid-tm", specifier = ">=2.6" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "zope-sqlalchemy", specifier = ">=4.1" },


### PR DESCRIPTION
## Summary

- **B1**: `get_engine` now uses `engine_from_config` so all `sqlalchemy.*` INI keys (pool_size, echo, etc.) are honoured
- **B2**: Added request-session tween ensuring `dbsession.info["request"]` is always set, fixing silent audit field skipping in the test/environ path
- **B3**: Testing plugin fixtures now set `REMOTE_ADDR` and wire `session.info["request"]` for proper audit field population
- **B4**: JSON renderer is opt-in via `config.sa_json_renderer()` directive instead of unconditionally overriding existing renderers (**breaking change**)
- **I1**: Include `pyramid_retry` by default for transient DB error handling
- **I2**: `includeme` checks both registry and settings for a pre-configured engine
- **I3**: `sa_scan_models` accepts module objects in addition to dotted strings
- **I6**: Error body formatters receive the caught exception via `exc` keyword argument
- **I4/I5**: Documented timezone behavior and testing plugin override points in knowledge files

Closes #29

## Breaking Changes

- `config.sa_json_renderer()` must now be called explicitly after `config.include("pyramid_sa")` — the renderer is no longer registered automatically
- Custom error formatters must accept `**kwargs` or an `exc` keyword argument

## Test plan

- [x] All 80 tests pass (including 4 new tests for B1, I2, I3, I1)
- [x] Audit fields populate correctly through plugin fixtures (new test)
- [x] Custom error formatters receive the exception object (updated tests)
- [x] Ruff + Black checks pass